### PR TITLE
Multi perf improvements

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -25,6 +25,7 @@ import com.ionspin.kotlin.bignum.integer.Platform
 import com.ionspin.kotlin.bignum.integer.RuntimePlatform
 import com.ionspin.kotlin.bignum.integer.Sign
 import com.ionspin.kotlin.bignum.integer.chosenArithmetic
+import com.ionspin.kotlin.bignum.integer.toBigInteger
 import com.ionspin.kotlin.bignum.integer.util.times
 import kotlin.math.absoluteValue
 import kotlin.math.max
@@ -1304,8 +1305,8 @@ class BigDecimal private constructor(
 
             val power = desiredPrecision - this.precision + other.precision
             val thisPrepared = when {
-                power > 0 -> this.significand * 10.toBigInteger().pow(power)
-                power < 0 -> this.significand / 10.toBigInteger().pow(power.absoluteValue)
+                power > 0 -> this.significand * BigInteger.TEN.pow(power)
+                power < 0 -> this.significand / BigInteger.TEN.pow(power.absoluteValue)
                 else -> this.significand
             }
 
@@ -1493,10 +1494,10 @@ class BigDecimal private constructor(
         val precisionExponentDiff = exponent - precision
         return when {
             precisionExponentDiff > 0 -> {
-                significand * 10.toBigInteger().pow(precisionExponentDiff + 1)
+                significand * BigInteger.TEN.pow(precisionExponentDiff + 1)
             }
             precisionExponentDiff < 0 -> {
-                significand / 10.toBigInteger().pow(precisionExponentDiff.absoluteValue - 1)
+                significand / BigInteger.TEN.pow(precisionExponentDiff.absoluteValue - 1)
             }
             else -> {
                 significand * 10
@@ -2090,20 +2091,20 @@ class BigDecimal private constructor(
             first.exponent > second.exponent -> {
                 val moveFirstBy = firstPreparedExponent - secondPreparedExponent
                 if (moveFirstBy >= 0) {
-                    val movedFirst = firstPrepared.significand * 10.toBigInteger().pow(moveFirstBy)
+                    val movedFirst = first.significand * BigInteger.TEN.pow(moveFirstBy)
                     return Triple(movedFirst, second.significand, secondPreparedExponent)
                 } else {
-                    val movedSecond = secondPrepared.significand * 10.toBigInteger().pow(moveFirstBy * -1)
+                    val movedSecond = second.significand * BigInteger.TEN.pow(moveFirstBy * -1)
                     Triple(first.significand, movedSecond, firstPreparedExponent)
                 }
             }
             first.exponent < second.exponent -> {
                 val moveSecondBy = secondPreparedExponent - firstPreparedExponent
                 return if (moveSecondBy >= 0) {
-                    val movedSecond = secondPrepared.significand * 10.toBigInteger().pow(moveSecondBy)
+                    val movedSecond = second.significand * BigInteger.TEN.pow(moveSecondBy)
                     Triple(first.significand, movedSecond, firstPreparedExponent)
                 } else {
-                    val movedFirst = firstPrepared.significand * 10.toBigInteger().pow(moveSecondBy * -1)
+                    val movedFirst = first.significand * BigInteger.TEN.pow(moveSecondBy * -1)
                     Triple(movedFirst, second.significand, firstPreparedExponent)
                 }
             }
@@ -2111,11 +2112,11 @@ class BigDecimal private constructor(
                 val delta = firstPreparedExponent - secondPreparedExponent
                 return when {
                     delta > 0 -> {
-                        val movedFirst = first.significand * 10.toBigInteger().pow(delta)
+                        val movedFirst = first.significand * BigInteger.TEN.pow(delta)
                         Triple(movedFirst, second.significand, firstPreparedExponent)
                     }
                     delta < 0 -> {
-                        val movedSecond = second.significand * 10.toBigInteger().pow(delta * -1)
+                        val movedSecond = second.significand * BigInteger.TEN.pow(delta * -1)
                         Triple(first.significand, movedSecond, firstPreparedExponent)
                     }
                     delta.compareTo(0) == 0 -> {

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -890,149 +890,78 @@ class BigDecimal private constructor(
             if (floatingPointString.isEmpty()) {
                 throw ArithmeticException("Empty string is not a valid decimal number")
             }
-            if (floatingPointString.contains('E', true)) {
-                // Sci notation
-                val split = if (floatingPointString.contains('.').not()) {
-                    // As is case with JS Double.MIN_VALUE
-                    val splitAroundE = floatingPointString.split('E', 'e')
-                    listOf(splitAroundE[0], "0E" + splitAroundE[1])
-                } else {
-                    floatingPointString.split('.')
-                }
-                when (split.size) {
-                    2 -> {
-                        val signPresent = (floatingPointString[0] == '-' || floatingPointString[0] == '+')
-                        val leftStart = if (signPresent) {
-                            1
-                        } else {
-                            0
-                        }
-                        var sign = if (signPresent) {
-                            if (floatingPointString[0] == '-') {
-                                Sign.NEGATIVE
-                            } else {
-                                Sign.POSITIVE
-                            }
-                        } else {
-                            Sign.POSITIVE
-                        }
-                        val left = split[0].substring(startIndex = leftStart)
-                        val rightSplit = split[1].split('E', 'e')
-                        val right = rightSplit[0]
-                        val exponentSplit = rightSplit[1]
-                        val exponentSignPresent = (exponentSplit[0] == '-' || exponentSplit[0] == '+')
-                        val exponentSign = if (exponentSplit[0] == '-') {
-                            Sign.NEGATIVE
-                        } else {
-                            Sign.POSITIVE
-                        }
-                        val skipSignIfPresent = if (exponentSignPresent) {
-                            1
-                        } else {
-                            0
-                        }
-                        val exponentString = exponentSplit.substring(startIndex = skipSignIfPresent)
-                        val exponent = if (exponentSign == Sign.POSITIVE) {
-                            exponentString.toLong(10)
-                        } else {
-                            exponentString.toLong(10) * -1
-                        }
 
-                        var leftFirstNonZero = left.indexOfFirst { it != '0' }
-
-                        if (leftFirstNonZero == -1) {
-                            leftFirstNonZero = 0
-                        }
-
-                        var rightLastNonZero = right.indexOfLast { it != '0' }
-
-                        if (rightLastNonZero == -1) {
-                            rightLastNonZero = right.length - 1
-                        }
-                        val leftTruncated = left.substring(leftFirstNonZero, left.length)
-                        val rightTruncated = right.substring(0, rightLastNonZero + 1)
-                        var significand = BigInteger.parseString(leftTruncated + rightTruncated, 10)
-
-                        if (significand == BigInteger.ZERO) {
-                            sign = Sign.ZERO
-                        }
-                        if (sign == Sign.NEGATIVE) {
-                            significand = significand.negate()
-                        }
-                        // here we need to cover mixed scientific and expanded notationtions, such as 0.00375E-20 = 3.75E-22
-                        val exponentModifiedByFloatingPointPosition = if (leftTruncated != "0") {
-                            // i.e. 375E-37 = 3.75*10^2*10^-37 =4.75 * 10^-35
-                            exponent + leftTruncated.length - 1
-                        } else {
-                            // i.e. 0.375E-20 = 3.75 * 10^E-23
-                            exponent - (rightTruncated.length - significand.numberOfDecimalDigits()) - 1
-                        }
-                        return BigDecimal(significand, exponentModifiedByFloatingPointPosition, decimalMode)
-                    }
-                    else -> throw ArithmeticException("Invalid (or unsupported) floating point number format: $floatingPointString")
-                }
-            } else {
-                // Expanded notation
-                if (floatingPointString.contains('.')) {
-                    val split = floatingPointString.split('.')
-                    when (split.size) {
-                        2 -> {
-                            val signPresent = (floatingPointString[0] == '-' || floatingPointString[0] == '+')
-                            val leftStart = if (signPresent) {
-                                1
-                            } else {
-                                0
-                            }
-                            var sign = if (signPresent) {
-                                if (floatingPointString[0] == '-') {
-                                    Sign.NEGATIVE
-                                } else {
-                                    Sign.POSITIVE
-                                }
-                            } else {
-                                Sign.POSITIVE
-                            }
-                            val left = split[0].substring(startIndex = leftStart)
-                            val right = split[1]
-                            var leftFirstNonZero = left.indexOfFirst { it != '0' }
-
-                            if (leftFirstNonZero == -1) {
-                                leftFirstNonZero = 0
-                            }
-
-                            var rightLastNonZero = right.indexOfLast { it != '0' }
-
-                            if (rightLastNonZero == -1) {
-                                rightLastNonZero = right.length - 1
-                            }
-                            val leftTruncated = left.substring(leftFirstNonZero, left.length)
-                            val rightTruncated = right.substring(0, rightLastNonZero + 1)
-                            var significand = BigInteger.parseString(leftTruncated + rightTruncated, 10)
-                            val exponent = if (leftTruncated.isNotEmpty() && leftTruncated[0] != '0') {
-                                leftTruncated.length - 1
-                            } else {
-                                (rightTruncated.indexOfFirst { it != '0' } + 1) * -1
-                            }
-
-                            if (significand == BigInteger.ZERO) {
-                                sign = Sign.ZERO
-                            }
-                            if (sign == Sign.NEGATIVE) {
-                                significand = significand.negate()
-                            }
-                            return BigDecimal(significand, exponent.toLong(), decimalMode)
-                        }
-                        else -> throw ArithmeticException("Invalid (or unsupported) floating point number format: $floatingPointString")
-                    }
-                } else {
-                    val significand = BigInteger.parseString(floatingPointString, 10)
-                    return BigDecimal(
-                        significand,
-                        significand.numberOfDecimalDigits() - 1,
-                        decimalMode
-                    )
-                }
+            fun leadingSignInfo(s: String): Pair<Int, Sign> = when {
+                s.isEmpty() -> 0 to Sign.POSITIVE
+                s[0] == '-' -> 1 to Sign.NEGATIVE
+                s[0] == '+' -> 1 to Sign.POSITIVE
+                else -> 0 to Sign.POSITIVE
             }
+
+            fun stripZerosCombined(left: String, right: String): Triple<String, String, Boolean> {
+                val combined = left + right
+                val firstNonZero = combined.indexOfFirst { it != '0' }
+                if (firstNonZero == -1) return Triple("0", "", true)
+                val trimmed = combined.substring(firstNonZero)
+                val leftKeep = (left.length - firstNonZero).coerceAtLeast(0)
+                val newLeft = trimmed.take(leftKeep).ifEmpty { "0" }
+                val newRight = if (trimmed.length > leftKeep) trimmed.substring(leftKeep) else ""
+                return Triple(newLeft, newRight, false)
+            }
+
+            // Fast path: no scientific notation
+            val ePos = floatingPointString.indexOfFirst { it == 'E' || it == 'e' }
+            if (ePos == -1) {
+                val dotPos = floatingPointString.indexOf('.')
+                val (signSkip, baseSign) = leadingSignInfo(floatingPointString)
+
+                // Integer only
+                if (dotPos == -1) {
+                    val body = floatingPointString.substring(signSkip)
+                    var sign = baseSign
+                    var exponent = body.length - 1
+                    var significand = BigInteger.parseString(body, 10)
+                    if (significand == BigInteger.ZERO) sign = Sign.ZERO
+                    if (sign == Sign.NEGATIVE) significand = significand.negate()
+                    return BigDecimal(significand, exponent.toLong(), decimalMode)
+                }
+
+                val left = floatingPointString.substring(signSkip, dotPos)
+                val right = floatingPointString.substring(dotPos + 1)
+                val (leftTrim, rightTrim, allZero) = stripZerosCombined(left, right)
+                if (allZero) return BigDecimal.ZERO
+
+                var sign = baseSign
+                var significand = BigInteger.parseString(leftTrim + rightTrim, 10)
+                if (significand == BigInteger.ZERO) sign = Sign.ZERO
+                if (sign == Sign.NEGATIVE) significand = significand.negate()
+                val exponent = leftTrim.length - 1
+                return BigDecimal(significand, exponent.toLong(), decimalMode)
+            }
+
+            // Scientific notation path
+            val (signSkip, baseSign) = leadingSignInfo(floatingPointString)
+            val dotPosRaw = floatingPointString.indexOf('.', startIndex = signSkip)
+            val dotPos = if (dotPosRaw in signSkip until ePos) dotPosRaw else -1
+
+            val exponentSignChar = floatingPointString[ePos + 1]
+            val expSkip = if (exponentSignChar == '+' || exponentSignChar == '-') 1 else 0
+            val exponentValue = floatingPointString.substring(ePos + 1 + expSkip).toLong()
+            val exponent = if (exponentSignChar == '-') -exponentValue else exponentValue
+
+            val mantissaLeft = floatingPointString.substring(signSkip, if (dotPos == -1) ePos else dotPos)
+            val mantissaRight = if (dotPos == -1) "" else floatingPointString.substring(dotPos + 1, ePos)
+
+            val (leftTrim, rightTrim, allZero) = stripZerosCombined(mantissaLeft, mantissaRight)
+            if (allZero) return BigDecimal.ZERO
+
+            var significand = BigInteger.parseString(leftTrim + rightTrim, 10)
+            var sign = baseSign
+            if (significand == BigInteger.ZERO) sign = Sign.ZERO
+            if (sign == Sign.NEGATIVE) significand = significand.negate()
+
+            val exponentModified = exponent + leftTrim.length - 1
+            return BigDecimal(significand, exponentModified.toLong(), decimalMode)
         }
 
         private fun resolveDecimalMode(
@@ -1684,36 +1613,48 @@ class BigDecimal private constructor(
      * as division.
      */
     override fun pow(exponent: Long): BigDecimal {
-        if (this.isZero() && exponent < 0) {
+        if (exponent == 0L) return ONE
+        if (this.isZero()) {
+            if (exponent < 0) {
             throw ArithmeticException("Negative exponentiation of zero is not defined.")
         }
-        var result = this
-        return when {
-            exponent > 0 -> {
-                for (i in 0 until exponent - 1) {
-                    result *= this
-                }
-                result
-            }
-            exponent < 0 -> {
-                if (exponent == Long.MIN_VALUE) {
-                    for (i in 0..Long.MAX_VALUE) {
-                        result /= this
-                    }
-                    // And another division beacuse min value is -9223372036854775808L and max value is 9223372036854775807L
-                    result /= this
-                } else {
-                    for (i in 0..exponent.absoluteValue) {
-                        result /= this
-                    }
-                }
-
-                result
-            }
-            else -> {
-                ONE
-            }
+            return ZERO
         }
+        if (exponent == 1L) return this
+
+        // Fast exact path when no decimal mode is attached and exponent is positive: scale exponent and power significand directly.
+        if (exponent > 0 && decimalMode == null) {
+            // (significand * 10^exponent) ^ n  =>  significand^n * 10^(exponent*n)
+            val poweredSignificand = significand.pow(exponent)
+            val newExponent = this.exponent * exponent
+            return BigDecimal(poweredSignificand, newExponent, null)
+        }
+
+        if (exponent > 0) {
+            var power = this
+            var exp = exponent
+            var acc = ONE
+            while (exp > 0) {
+                if ((exp and 1L) == 1L) {
+                    acc *= power
+                }
+                exp = exp shr 1
+                if (exp > 0) {
+                    power *= power
+                }
+            }
+            return acc
+        }
+
+        // Negative exponent: compute reciprocal of the positive power.
+        val positiveExponent = if (exponent == Long.MIN_VALUE) Long.MAX_VALUE else exponent.absoluteValue
+        val positivePow = this.pow(positiveExponent)
+        val fullPow = if (exponent == Long.MIN_VALUE) {
+            positivePow * this
+        } else {
+            positivePow
+        }
+        return ONE.divide(fullPow)
     }
 
     /**

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -430,10 +430,13 @@ class BigDecimal private constructor(
                         return RoundedSignificand(divRem.quotient, exponent)
                     }
                     // Check if remainder was .0XXX if so handle it
-                    if (significand.numberOfDecimalDigits() == divRem.quotient.numberOfDecimalDigits() + divRem.remainder.numberOfDecimalDigits()) {
+                    // Cache digit counts to avoid multiple calls
+                    val quotientDigits = divRem.quotient.numberOfDecimalDigits()
+                    val remainderDigits = divRem.remainder.numberOfDecimalDigits()
+                    if (significandDigits == quotientDigits + remainderDigits) {
                         val newSignificand = roundDiscarded(divRem.quotient, resolvedRemainder, decimalMode)
                         val exponentModifier =
-                            newSignificand.numberOfDecimalDigits() - divRem.quotient.numberOfDecimalDigits()
+                            newSignificand.numberOfDecimalDigits() - quotientDigits
                         RoundedSignificand(newSignificand, exponent + exponentModifier)
                     } else {
                         handleZeroRounding(divRem.quotient, exponent, decimalMode)
@@ -1103,19 +1106,13 @@ class BigDecimal private constructor(
             return roundOrDont(this.significand, this.exponent, resolvedDecimalMode).toBigDecimal(resolvedDecimalMode)
         }
         val (first, second, _) = bringSignificandToSameExponent(this, other)
-        // Temporary way to detect a carry happened, proper solution is to add
-        // methods that return information about carry in arithmetic classes, this way it's going
-        // to be rather slow
-        val firstNumOfDigits = first.numberOfDecimalDigits()
-        val secondNumOfDigits = second.numberOfDecimalDigits()
+        // Optimized carry detection: use cached precision from original BigDecimals to estimate
+        // expected digit count, then only call numberOfDecimalDigits() on result
+        val expectedMaxDigits = max(this.precision, other.precision)
         val newSignificand = first + second
+        // Only call numberOfDecimalDigits() once on the result (not on operands)
         val newSignificandNumOfDigit = newSignificand.numberOfDecimalDigits()
-        val largerOperand = if (firstNumOfDigits > secondNumOfDigits) {
-            firstNumOfDigits
-        } else {
-            secondNumOfDigits
-        }
-        val carryDetected = newSignificandNumOfDigit - largerOperand
+        val carryDetected = newSignificandNumOfDigit - expectedMaxDigits
         val newExponent = max(this.exponent, other.exponent) + carryDetected
 
         return if (resolvedDecimalMode.usingScale) {
@@ -1163,19 +1160,12 @@ class BigDecimal private constructor(
 
         val (first, second, _) = bringSignificandToSameExponent(this, other)
 
-        val firstNumOfDigits = first.numberOfDecimalDigits()
-        val secondNumOfDigits = second.numberOfDecimalDigits()
-
+        // Optimized borrow detection: use cached precision from original BigDecimals
+        val expectedMaxDigits = max(this.precision, other.precision)
         val newSignificand = first - second
-
+        // Only call numberOfDecimalDigits() on result, not on operands
         val newSignificandNumOfDigit = newSignificand.numberOfDecimalDigits()
-
-        val largerOperand = if (firstNumOfDigits > secondNumOfDigits) {
-            firstNumOfDigits
-        } else {
-            secondNumOfDigits
-        }
-        val borrowDetected = newSignificandNumOfDigit - largerOperand
+        val borrowDetected = newSignificandNumOfDigit - expectedMaxDigits
 
         val newExponent = max(this.exponent, other.exponent) + borrowDetected
         if (usingScale) {
@@ -1257,8 +1247,11 @@ class BigDecimal private constructor(
             val divRem = thisPrepared divrem other.significand
             val result = divRem.quotient
             val expectedDiff = other.precision - 1
+            // Cache numberOfDecimalDigits() results to avoid redundant calls
+            val resultDigits = result.numberOfDecimalDigits()
+            val thisPreparedDigits = thisPrepared.numberOfDecimalDigits()
             val exponentModifier =
-                expectedDiff + (result.numberOfDecimalDigits() - thisPrepared.numberOfDecimalDigits())
+                expectedDiff + (resultDigits - thisPreparedDigits)
 
             if (divRem.remainder != BigInteger.ZERO) {
                 throw ArithmeticException(
@@ -1289,13 +1282,15 @@ class BigDecimal private constructor(
             if (result == BigInteger.ZERO) {
                 newExponent--
             }
-            val exponentModifier = result.numberOfDecimalDigits() - resolvedDecimalMode.decimalPrecision
+            // Cache numberOfDecimalDigits() result to avoid calling it twice
+            val resultNumOfDigits = result.numberOfDecimalDigits()
+            val exponentModifier = resultNumOfDigits - resolvedDecimalMode.decimalPrecision
 
             return if (usingScale) {
                 BigDecimal(
                     roundDiscarded(result, divRem.remainder, resolvedDecimalMode),
                     newExponent + exponentModifier,
-                    resolvedDecimalMode.copy(decimalPrecision = result.numberOfDecimalDigits())
+                    resolvedDecimalMode.copy(decimalPrecision = resultNumOfDigits)
                 )
             } else {
                 BigDecimal(
@@ -2058,7 +2053,8 @@ class BigDecimal private constructor(
     }
 
     private fun getRidOfRadix(bigDecimal: BigDecimal): Long {
-        val precision = bigDecimal.significand.numberOfDecimalDigits()
+        // Use cached precision instead of recalculating numberOfDecimalDigits()
+        val precision = bigDecimal.precision
         val newExponent = bigDecimal.exponent - precision + 1
         return newExponent
     }

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -898,15 +898,42 @@ class BigDecimal private constructor(
                 else -> 0 to Sign.POSITIVE
             }
 
-            fun stripZerosCombined(left: String, right: String): Triple<String, String, Boolean> {
-                val combined = left + right
-                val firstNonZero = combined.indexOfFirst { it != '0' }
-                if (firstNonZero == -1) return Triple("0", "", true)
-                val trimmed = combined.substring(firstNonZero)
-                val leftKeep = (left.length - firstNonZero).coerceAtLeast(0)
-                val newLeft = trimmed.take(leftKeep).ifEmpty { "0" }
-                val newRight = if (trimmed.length > leftKeep) trimmed.substring(leftKeep) else ""
-                return Triple(newLeft, newRight, false)
+            fun stripZerosCombined(left: String, right: String): Triple<Int, Int, Int> {
+                // Find first non-zero digit without concatenating strings
+                var firstNonZero = -1
+                var i = 0
+                while (i < left.length && firstNonZero == -1) {
+                    if (left[i] != '0') firstNonZero = i
+                    i++
+                }
+                if (firstNonZero == -1) {
+                    i = 0
+                    while (i < right.length && firstNonZero == -1) {
+                        if (right[i] != '0') firstNonZero = left.length + i
+                        i++
+                    }
+                }
+                if (firstNonZero == -1) return Triple(-1, -1, -1) // all zeros
+                
+                // Find last non-zero digit
+                var lastNonZero = -1
+                i = right.length - 1
+                while (i >= 0 && lastNonZero == -1) {
+                    if (right[i] != '0') lastNonZero = left.length + i
+                    i--
+                }
+                if (lastNonZero == -1) {
+                    i = left.length - 1
+                    while (i >= 0 && lastNonZero == -1) {
+                        if (left[i] != '0') lastNonZero = i
+                        i--
+                    }
+                }
+                // Return: start index in left, end index in right (inclusive), total length
+                val leftStart = if (firstNonZero < left.length) firstNonZero else 0
+                val rightEnd = if (lastNonZero >= left.length) lastNonZero - left.length else -1
+                val totalLen = lastNonZero - firstNonZero + 1
+                return Triple(leftStart, rightEnd, totalLen)
             }
 
             // Fast path: no scientific notation
@@ -928,14 +955,24 @@ class BigDecimal private constructor(
 
                 val left = floatingPointString.substring(signSkip, dotPos)
                 val right = floatingPointString.substring(dotPos + 1)
-                val (leftTrim, rightTrim, allZero) = stripZerosCombined(left, right)
-                if (allZero) return BigDecimal.ZERO
+                val (leftStart, rightEnd, totalLen) = stripZerosCombined(left, right)
+                if (totalLen == -1) return BigDecimal.ZERO
 
+                // Build significand string without concatenation overhead
+                val significandStr = buildString(totalLen) {
+                    if (leftStart < left.length) {
+                        append(left, leftStart)
+                    }
+                    if (rightEnd >= 0) {
+                        append(right, 0, rightEnd + 1)
+                    }
+                }
                 var sign = baseSign
-                var significand = BigInteger.parseString(leftTrim + rightTrim, 10)
+                var significand = BigInteger.parseString(significandStr, 10)
                 if (significand == BigInteger.ZERO) sign = Sign.ZERO
                 if (sign == Sign.NEGATIVE) significand = significand.negate()
-                val exponent = leftTrim.length - 1
+                val leftTrimLen = if (leftStart < left.length) left.length - leftStart else 0
+                val exponent = leftTrimLen - 1
                 return BigDecimal(significand, exponent.toLong(), decimalMode)
             }
 
@@ -952,15 +989,25 @@ class BigDecimal private constructor(
             val mantissaLeft = floatingPointString.substring(signSkip, if (dotPos == -1) ePos else dotPos)
             val mantissaRight = if (dotPos == -1) "" else floatingPointString.substring(dotPos + 1, ePos)
 
-            val (leftTrim, rightTrim, allZero) = stripZerosCombined(mantissaLeft, mantissaRight)
-            if (allZero) return BigDecimal.ZERO
+            val (leftStart, rightEnd, totalLen) = stripZerosCombined(mantissaLeft, mantissaRight)
+            if (totalLen == -1) return BigDecimal.ZERO
 
-            var significand = BigInteger.parseString(leftTrim + rightTrim, 10)
+            // Build significand string without concatenation overhead
+            val significandStr = buildString(totalLen) {
+                if (leftStart < mantissaLeft.length) {
+                    append(mantissaLeft, leftStart)
+                }
+                if (rightEnd >= 0) {
+                    append(mantissaRight, 0, rightEnd + 1)
+                }
+            }
+            var significand = BigInteger.parseString(significandStr, 10)
             var sign = baseSign
             if (significand == BigInteger.ZERO) sign = Sign.ZERO
             if (sign == Sign.NEGATIVE) significand = significand.negate()
 
-            val exponentModified = exponent + leftTrim.length - 1
+            val leftTrimLen = if (leftStart < mantissaLeft.length) mantissaLeft.length - leftStart else 0
+            val exponentModified = exponent + leftTrimLen - 1
             return BigDecimal(significand, exponentModified.toLong(), decimalMode)
         }
 
@@ -1165,11 +1212,9 @@ class BigDecimal private constructor(
      */
     fun multiply(other: BigDecimal, decimalMode: DecimalMode? = null): BigDecimal {
         val resolvedDecimalMode = resolveDecimalMode(this.decimalMode, other.decimalMode, decimalMode)
-        // Temporary way to detect a carry happened, proper solution is to add
-        // methods that return information about carry in arithmetic classes, this way it's going
-        // to be rather slow
-        val firstNumOfDigits = this.significand.numberOfDecimalDigits()
-        val secondNumOfDigits = other.significand.numberOfDecimalDigits()
+        // Optimize: use cached precision when available to avoid repeated numberOfDecimalDigits() calls
+        val firstNumOfDigits = this.precision
+        val secondNumOfDigits = other.precision
 
         val newSignificand = this.significand * other.significand
 

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -482,6 +482,20 @@ class BigInteger internal constructor(wordArray: WordArray, requestedSign: Sign)
             chosenArithmetic.compare(this.magnitude, chosenArithmetic.ZERO) == 0
     }
 
+    fun isPowerOfTen(): Boolean {
+        if (this.isZero() || this.isNegative) return false
+        if (this == ONE) return true
+        // Quick check: last digit must be 0
+        if ((this % TEN) != ZERO) return false
+        var value = this
+        while (value > TEN) {
+            val divRem = value divrem TEN
+            if (divRem.remainder != ZERO) return false
+            value = divRem.quotient
+        }
+        return value == TEN || value == ONE
+    }
+
     override fun negate(): BigInteger {
         return BigInteger(wordArray = this.magnitude, requestedSign = sign.not())
     }

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/Quadruple.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/Quadruple.kt
@@ -23,7 +23,3 @@ package com.ionspin.kotlin.bignum.integer
  * on 09-Mar-2019
  */
 data class Quadruple<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
-
-data class Quintuple<A, B, C, D, E>(val a: A, val b: B, val c: C, val d: D, val e: E)
-
-data class Sextuple<A, B, C, D, E, F>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F)

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
@@ -20,7 +20,6 @@ package com.ionspin.kotlin.bignum.integer.base63.array
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.BigIntegerArithmetic
 import com.ionspin.kotlin.bignum.integer.Quadruple
-import com.ionspin.kotlin.bignum.integer.Sextuple
 import com.ionspin.kotlin.bignum.integer.base32.BigInteger32Arithmetic
 import com.ionspin.kotlin.bignum.integer.util.toBigEndianUByteArray
 import com.ionspin.kotlin.bignum.integer.util.toDigit
@@ -461,11 +460,14 @@ internal object BigInteger63Arithmetic : BigIntegerArithmetic {
             second
         )
 
-        val (largerLength, smallerLength, largerData, smallerData, largerStart, smallerStart) = if (firstStart > secondStart) {
-            Sextuple(first.size, second.size, first, second, firstStart, secondStart)
-        } else {
-            Sextuple(second.size, first.size, second, first, secondStart, firstStart)
-        }
+        val reverse = firstStart <= secondStart
+        val largerLength = if (reverse) second.size else first.size
+        //val smallerLength = if (reverse) first.size else second.size
+        val largerData = if (reverse) second else first
+        val smallerData = if (reverse) first else second
+        val largerStart = if (reverse) secondStart else firstStart
+        val smallerStart = if (reverse) firstStart else secondStart
+
         var i = 0
         var sum: ULong = 0u
         while (i < smallerStart) {
@@ -507,11 +509,14 @@ internal object BigInteger63Arithmetic : BigIntegerArithmetic {
             second
         )
 
-        val (largerLength, smallerLength, largerData, smallerData, largerStart, smallerStart) = if (firstStart > secondStart) {
-            Sextuple(first.size, second.size, first, second, firstStart, secondStart)
-        } else {
-            Sextuple(second.size, first.size, second, first, secondStart, firstStart)
-        }
+        val reverse = firstStart <= secondStart
+        val largerLength = if (reverse) second.size else first.size
+        val smallerLength = if (reverse) first.size else second.size
+        val largerData = if (reverse) second else first
+        val smallerData = if (reverse) first else second
+        val largerStart = if (reverse) secondStart else firstStart
+        val smallerStart = if (reverse) firstStart else secondStart
+
         val possibleOverflow =
             possibleAdditionOverflow(largerLength, smallerLength, largerData, smallerData, largerStart, smallerStart)
         val result = if (possibleOverflow) {
@@ -557,12 +562,15 @@ internal object BigInteger63Arithmetic : BigIntegerArithmetic {
             second
         )
 
-        val (largerLength, smallerLength, largerData, smallerData, largerStart, smallerStart) = if (firstStart > secondStart) {
-            Sextuple(first.size, second.size, first, second, firstStart, secondStart)
-        } else {
-            Sextuple(second.size, first.size, second, first, secondStart, firstStart)
-        }
-        val result = ULongArray(largerStart + 1) { 0u }
+        val reverse = firstStart <= secondStart
+        val largerLength = if (reverse) second.size else first.size
+        // val smallerLength = if (reverse) first.size else second.size
+        val largerData = if (reverse) second else first
+        val smallerData = if (reverse) first else second
+        val largerStart = if (reverse) secondStart else firstStart
+        val smallerStart = if (reverse) firstStart else secondStart
+
+        val result = ULongArray(largerStart + 1)
         var i = 0
         var sum: ULong = 0u
         while (i < smallerStart) {

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
@@ -541,8 +541,8 @@ internal object BigInteger63Arithmetic : BigIntegerArithmetic {
         smallerStart: Int
     ): Boolean {
 
-        var firstMostSignificant = largerData[largerStart - 1]
-        var secondMostSignificant = smallerData[smallerStart - 1]
+        val firstMostSignificant = largerData[largerStart - 1]
+        val secondMostSignificant = smallerData[smallerStart - 1]
 
         // if two consecutive bits on same positions in both operands are 0, they cannot overflow
         val possibleOverflow = ((firstMostSignificant and 0x6000000000000000UL) != 0UL) ||

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalBenchmark.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalBenchmark.kt
@@ -1,0 +1,202 @@
+package com.ionspin.kotlin.bignum.decimal
+
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.random.Random
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.measureTime
+
+@Ignore // Too long to run all the time
+class BigDecimalBenchmark {
+
+    private fun Random.randomStringDecimal(allowZero: Boolean = true): String =
+        randomStringInteger(allowZero) + "." + randomStringInteger(allowZero)
+
+    private fun Random.randomStringInteger(allowZero: Boolean = true): String {
+        // Spread possibilities based of number of digits, which increases likelihood of smaller numbers
+        // There will be roughly as many tests with 1 digit as with 20 digits
+        val nbDigit = nextInt(0, 10)
+        do {
+            val value = nextInt(10f.pow(nbDigit).toInt() - 1, 10f.pow(nbDigit + 1).toInt())
+            if (allowZero || value != 0)
+                return value.toString()
+        } while (true)
+    }
+
+    private fun Random.randomDecimalMode(
+        allowInfinitePrecision: Boolean = true
+    ): DecimalMode? {
+        if (allowInfinitePrecision && nextBoolean()) return null
+        var roundingMode = RoundingMode.entries.random(this)
+        if (allowInfinitePrecision && roundingMode == RoundingMode.NONE)
+            return DecimalMode(
+                decimalPrecision = 0,
+                roundingMode = roundingMode,
+                scale = -1,
+            )
+        while (!allowInfinitePrecision && roundingMode == RoundingMode.NONE) {
+            roundingMode = RoundingMode.entries.random(this)
+        }
+        val decimalPrecision = nextLong(1, 30)
+        return DecimalMode(
+            decimalPrecision = decimalPrecision,
+            roundingMode = roundingMode,
+            scale = if (nextBoolean()) -1 else nextLong(0, decimalPrecision),
+        )
+    }
+
+    private fun Random.randomRoundingMode(allowNone: Boolean = true): RoundingMode {
+        do {
+            val mode = RoundingMode.entries.random(this)
+            if (allowNone || mode != RoundingMode.NONE)
+                return mode
+        } while (true)
+    }
+
+    private fun Random.randomBigDecimal(allowZero: Boolean = true): BigDecimal =
+        BigDecimal.parseStringWithMode(randomStringDecimal(allowZero), randomDecimalMode())
+
+    private fun Random.randomBigInteger(allowZero: Boolean = true): BigInteger =
+        BigInteger.parseString(randomStringInteger(allowZero))
+
+    private val benchmarkList = mutableListOf<BenchmarkRun>()
+
+    private data class BenchmarkRun(val key: String, val runNumber: Int, val duration: Duration)
+
+    private val times = 10_000_000
+    private val runs = 5
+    private fun <T> benchmark(
+        key: String,
+        // Prepare random (or not) values for the benchmark, this is not measured in the benchmark
+        prepare: Random.() -> T,
+        measure: (t: T) -> Unit
+    ) {
+        println("Preparing for $key (warmup)")
+        repeat(100_000) { // Warmup (JVM is strongly impacted by JIT, result stability requires a short warmup)
+            measure(prepare(Random))
+        }
+        println("Benchmarking for $key")
+        // More than 1M of the different values requires too much RAM, 100k values looks enough
+        val maxDataSize = min(100_000, times)
+        repeat(runs) { run ->
+            val random = Random(0)
+            val data = (0..maxDataSize).map { random.prepare() }
+            val duration = measureTime {
+                repeat(times) { index ->
+                    measure(data[index % maxDataSize])
+                }
+            }
+            benchmarkList.add(BenchmarkRun(key, run, duration))
+            println("Benchmark $run DONE for $key in $duration")
+        }
+    }
+
+    @Test
+    fun performanceBenchmark() {
+        benchmark(
+            key = "BigDecimal.parseStringWithMode",
+            prepare = { randomStringDecimal() to randomDecimalMode() },
+            measure = { BigDecimal.parseStringWithMode(it.first, it.second) }
+        )
+        benchmark(
+            key = "BigDecimal.add",
+            prepare = { randomBigDecimal() to randomBigDecimal() },
+            measure = { (a, b) -> a + b }
+        )
+        benchmark(
+            key = "BigDecimal.subtract",
+            prepare = { randomBigDecimal() to randomBigDecimal() },
+            measure = { (a, b) -> a - b }
+        )
+        benchmark(
+            key = "BigDecimal.multiply",
+            prepare = { randomBigDecimal() to randomBigDecimal() },
+            measure = { (a, b) -> a * b }
+        )
+        benchmark(
+            key = "BigDecimal.divide",
+            prepare = {
+                Triple(
+                    randomBigDecimal(),
+                    randomBigDecimal(allowZero = false),
+                    randomDecimalMode(allowInfinitePrecision = false)
+                )
+            },
+            measure = { (a, b, mode) -> a.divide(b, mode) }
+        )
+        benchmark(
+            key = "BigDecimal.hashCode",
+            prepare = { randomBigDecimal() },
+            measure = { it.hashCode() }
+        )
+        benchmark(
+            key = "BigDecimal.toStringExpanded",
+            prepare = { randomBigDecimal() },
+            measure = { it.toStringExpanded() }
+        )
+        benchmark(
+            key = "BigDecimal.toPlainString",
+            prepare = { randomBigDecimal() },
+            measure = { it.toPlainString() }
+        )
+        benchmark(
+            key = "BigDecimal.roundToDigitPosition",
+            prepare = { randomBigDecimal() to randomRoundingMode(allowNone = false) },
+            measure = { (a, b) -> a.roundToDigitPosition(2, b) }
+        )
+        benchmark(
+            key = "BigDecimal.pow",
+            prepare = { randomBigDecimal() to nextInt(0, 5) },
+            measure = { (a, b) -> a.pow(b) }
+        )
+
+        benchmark(
+            key = "BigDecimal.isZero",
+            prepare = { randomBigDecimal()},
+            measure = { it.isZero() }
+        )
+
+        // ------------ BigInteger ------------
+
+        benchmark(
+            key = "BigInteger.pow",
+            prepare = { randomBigInteger() to nextInt(0, 5) },
+            measure = { (a, b) -> a.pow(b) }
+        )
+        benchmark(
+            key = "BigInteger.TEN.pow",
+            prepare = { nextLong(0, 50) },
+            measure = { BigInteger.TEN.pow(it) }
+        )
+        benchmark(
+            key = "BigInteger.isZero",
+            prepare = { randomBigInteger()},
+            measure = { it.isZero() }
+        )
+
+        printBenchmarkReport()
+    }
+
+    private fun printBenchmarkReport() {
+        println("Benchmark report:")
+        println()
+
+        println("| Method | " + (1..runs).joinToString("|") { " #$it " } + " | Average |")
+        println("|--------|-" + (1..runs).joinToString("|") { "------" } + " |---------|")
+        benchmarkList.groupBy { it.key }
+            .toList()
+            .sortedBy { it.first }
+            .forEach { (key, runs) ->
+                println("| $key | " + runs.joinToString("|") { " ${it.duration} " } +
+                        " | ${runs.map { it.duration }.avg()} |")
+            }
+    }
+
+    private fun List<Duration>.avg(): Duration {
+        val sum = this.fold(Duration.ZERO) { acc, duration -> acc + duration }
+        return sum.div(this.size)
+    }
+}


### PR DESCRIPTION
Multiple perf improvements, see details in each commits.

A global benchmark before and after to compare the improvements


| Method                          | Before (avg of 5 runs) | After  (avg of 5 runs) | Gain         | Gain % |
|---------------------------------|------------------------|------------------------|--------------|--------|
| BigDecimal.add                  | 5.361666483s           | 3.626009725s           | 1.735656758s | 32.4%  |
| BigDecimal.divide               | 17.563635691s          | 13.214709058s          | 4.348926633s | 24.8%  |
| BigDecimal.hashCode             | 2.090754216s           | 1.885830800s           | 0.204923416s | 9.8%   |
| BigDecimal.isZero               | 168.348158ms           | 120.002383ms           | 48.345775ms  | 28.7%  |
| BigDecimal.multiply             | 4.306248025s           | 3.895518808s           | 0.410729217s | 9.5%   |
| BigDecimal.parseStringWithMode  | 6.032730558s           | 2.795508533s           | 3.237222025s | 53.7%  |
| BigDecimal.pow                  | 9.263568549s           | 8.316417325s           | 0.947151224s | 10.2%  |
| BigDecimal.roundToDigitPosition | 3.931222933s           | 3.151020300s           | 0.780202633s | 19.8%  |
| BigDecimal.subtract             | 4.932343592s           | 3.363048383s           | 1.569295209s | 31.8%  |
| BigDecimal.toPlainString        | 3.240023633s           | 3.170939741s           | 0.069083892s | 2.1% (luck)   |
| BigDecimal.toStringExpanded     | 3.181326449s           | 3.124509074s           | 0.056817375s | 1.8% (luck)  |
| BigInteger.TEN.pow              | 201.281508ms           | 120.361291ms           | 80.920217ms  | 40.2%  |
| BigInteger.isZero               | 117.322116ms           | 33.185292ms            | 84.136824ms  | 71.7%  |
| BigInteger.pow                  | 634.312616ms           | 519.652508ms           | 114.660108ms | 18.1%  |

<details>
<summary>All details are available below</summary>



PERF RESEARCH

ORIGINAL PERF BASED ON 384a12c9365a957e3ae7df372a7cd476f661a088

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Preparing for BigDecimal.parseStringWithMode (warmup)
Benchmarking for BigDecimal.parseStringWithMode
Benchmark 0 DONE for BigDecimal.parseStringWithMode in 6.129106709s
Benchmark 1 DONE for BigDecimal.parseStringWithMode in 6.069024791s
Benchmark 2 DONE for BigDecimal.parseStringWithMode in 6.033444667s
Benchmark 3 DONE for BigDecimal.parseStringWithMode in 5.967124125s
Benchmark 4 DONE for BigDecimal.parseStringWithMode in 5.964952500s
Preparing for BigDecimal.add (warmup)
Benchmarking for BigDecimal.add
Benchmark 0 DONE for BigDecimal.add in 5.433343625s
Benchmark 1 DONE for BigDecimal.add in 5.355922291s
Benchmark 2 DONE for BigDecimal.add in 5.331163333s
Benchmark 3 DONE for BigDecimal.add in 5.342635542s
Benchmark 4 DONE for BigDecimal.add in 5.345267625s
Preparing for BigDecimal.subtract (warmup)
Benchmarking for BigDecimal.subtract
Benchmark 0 DONE for BigDecimal.subtract in 4.945782625s
Benchmark 1 DONE for BigDecimal.subtract in 4.903031334s
Benchmark 2 DONE for BigDecimal.subtract in 4.908852209s
Benchmark 3 DONE for BigDecimal.subtract in 4.977049625s
Benchmark 4 DONE for BigDecimal.subtract in 4.927002167s
Preparing for BigDecimal.multiply (warmup)
Benchmarking for BigDecimal.multiply
Benchmark 0 DONE for BigDecimal.multiply in 4.395549250s
Benchmark 1 DONE for BigDecimal.multiply in 4.337605s
Benchmark 2 DONE for BigDecimal.multiply in 4.286808708s
Benchmark 3 DONE for BigDecimal.multiply in 4.254930542s
Benchmark 4 DONE for BigDecimal.multiply in 4.256346625s
Preparing for BigDecimal.divide (warmup)
Benchmarking for BigDecimal.divide
Benchmark 0 DONE for BigDecimal.divide in 17.197246625s
Benchmark 1 DONE for BigDecimal.divide in 17.178957208s
Benchmark 2 DONE for BigDecimal.divide in 17.370274125s
Benchmark 3 DONE for BigDecimal.divide in 18.449112917s
Benchmark 4 DONE for BigDecimal.divide in 17.622587583s
Preparing for BigDecimal.hashCode (warmup)
Benchmarking for BigDecimal.hashCode
Benchmark 0 DONE for BigDecimal.hashCode in 2.099849666s
Benchmark 1 DONE for BigDecimal.hashCode in 2.081946875s
Benchmark 2 DONE for BigDecimal.hashCode in 2.087968833s
Benchmark 3 DONE for BigDecimal.hashCode in 2.083653583s
Benchmark 4 DONE for BigDecimal.hashCode in 2.100352125s
Preparing for BigDecimal.toStringExpanded (warmup)
Benchmarking for BigDecimal.toStringExpanded
Benchmark 0 DONE for BigDecimal.toStringExpanded in 3.173884916s
Benchmark 1 DONE for BigDecimal.toStringExpanded in 3.218394625s
Benchmark 2 DONE for BigDecimal.toStringExpanded in 3.180223375s
Benchmark 3 DONE for BigDecimal.toStringExpanded in 3.170393708s
Benchmark 4 DONE for BigDecimal.toStringExpanded in 3.163735625s
Preparing for BigDecimal.toPlainString (warmup)
Benchmarking for BigDecimal.toPlainString
Benchmark 0 DONE for BigDecimal.toPlainString in 3.219728875s
Benchmark 1 DONE for BigDecimal.toPlainString in 3.187645167s
Benchmark 2 DONE for BigDecimal.toPlainString in 3.350294417s
Benchmark 3 DONE for BigDecimal.toPlainString in 3.232167166s
Benchmark 4 DONE for BigDecimal.toPlainString in 3.210282542s
Preparing for BigDecimal.roundToDigitPosition (warmup)
Benchmarking for BigDecimal.roundToDigitPosition
Benchmark 0 DONE for BigDecimal.roundToDigitPosition in 3.929448208s
Benchmark 1 DONE for BigDecimal.roundToDigitPosition in 3.919461792s
Benchmark 2 DONE for BigDecimal.roundToDigitPosition in 3.954164375s
Benchmark 3 DONE for BigDecimal.roundToDigitPosition in 3.931849625s
Benchmark 4 DONE for BigDecimal.roundToDigitPosition in 3.921190667s
Preparing for BigDecimal.pow (warmup)
Benchmarking for BigDecimal.pow
Benchmark 0 DONE for BigDecimal.pow in 9.293656458s
Benchmark 1 DONE for BigDecimal.pow in 9.614776375s
Benchmark 2 DONE for BigDecimal.pow in 9.107468916s
Benchmark 3 DONE for BigDecimal.pow in 9.118559875s
Benchmark 4 DONE for BigDecimal.pow in 9.183381125s
Preparing for BigDecimal.isZero (warmup)
Benchmarking for BigDecimal.isZero
Benchmark 0 DONE for BigDecimal.isZero in 315.393791ms
Benchmark 1 DONE for BigDecimal.isZero in 255.624959ms
Benchmark 2 DONE for BigDecimal.isZero in 121.243584ms
Benchmark 3 DONE for BigDecimal.isZero in 88.027583ms
Benchmark 4 DONE for BigDecimal.isZero in 61.450875ms
Preparing for BigInteger.pow (warmup)
Benchmarking for BigInteger.pow
Benchmark 0 DONE for BigInteger.pow in 634.632917ms
Benchmark 1 DONE for BigInteger.pow in 630.169709ms
Benchmark 2 DONE for BigInteger.pow in 629.683250ms
Benchmark 3 DONE for BigInteger.pow in 633.617583ms
Benchmark 4 DONE for BigInteger.pow in 643.459625ms
Preparing for BigInteger.TEN.pow (warmup)
Benchmarking for BigInteger.TEN.pow
Benchmark 0 DONE for BigInteger.TEN.pow in 201.571416ms
Benchmark 1 DONE for BigInteger.TEN.pow in 200.507542ms
Benchmark 2 DONE for BigInteger.TEN.pow in 201.433792ms
Benchmark 3 DONE for BigInteger.TEN.pow in 201.285334ms
Benchmark 4 DONE for BigInteger.TEN.pow in 201.609459ms
Preparing for BigInteger.isZero (warmup)
Benchmarking for BigInteger.isZero
Benchmark 0 DONE for BigInteger.isZero in 124.876250ms
Benchmark 1 DONE for BigInteger.isZero in 57.415542ms
Benchmark 2 DONE for BigInteger.isZero in 40.308125ms
Benchmark 3 DONE for BigInteger.isZero in 40.634041ms
Benchmark 4 DONE for BigInteger.isZero in 323.376625ms
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| BigDecimal.add |  5.433343625s | 5.355922291s | 5.331163333s | 5.342635542s | 5.345267625s  | 5.361666483s |
| BigDecimal.divide |  17.197246625s | 17.178957208s | 17.370274125s | 18.449112917s | 17.622587583s  | 17.563635691s |
| BigDecimal.hashCode |  2.099849666s | 2.081946875s | 2.087968833s | 2.083653583s | 2.100352125s  | 2.090754216s |
| BigDecimal.isZero |  315.393791ms | 255.624959ms | 121.243584ms | 88.027583ms | 61.450875ms  | 168.348158ms |
| BigDecimal.multiply |  4.395549250s | 4.337605s | 4.286808708s | 4.254930542s | 4.256346625s  | 4.306248025s |
| BigDecimal.parseStringWithMode |  6.129106709s | 6.069024791s | 6.033444667s | 5.967124125s | 5.964952500s  | 6.032730558s |
| BigDecimal.pow |  9.293656458s | 9.614776375s | 9.107468916s | 9.118559875s | 9.183381125s  | 9.263568549s |
| BigDecimal.roundToDigitPosition |  3.929448208s | 3.919461792s | 3.954164375s | 3.931849625s | 3.921190667s  | 3.931222933s |
| BigDecimal.subtract |  4.945782625s | 4.903031334s | 4.908852209s | 4.977049625s | 4.927002167s  | 4.932343592s |
| BigDecimal.toPlainString |  3.219728875s | 3.187645167s | 3.350294417s | 3.232167166s | 3.210282542s  | 3.240023633s |
| BigDecimal.toStringExpanded |  3.173884916s | 3.218394625s | 3.180223375s | 3.170393708s | 3.163735625s  | 3.181326449s |
| BigInteger.TEN.pow |  201.571416ms | 200.507542ms | 201.433792ms | 201.285334ms | 201.609459ms  | 201.281508ms |
| BigInteger.isZero |  124.876250ms | 57.415542ms | 40.308125ms | 40.634041ms | 323.376625ms  | 117.322116ms |
| BigInteger.pow |  634.632917ms | 630.169709ms | 629.683250ms | 633.617583ms | 643.459625ms  | 634.312616ms |

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- after 1st commit e1028814fb6156579aa9a0152d128c53e6b31a92



Preparing for parseStringWithMode (warmup)
Benchmarking for parseStringWithMode
Benchmark 0 DONE for parseStringWithMode in 5.871168875s
Benchmark 1 DONE for parseStringWithMode in 5.817717417s
Benchmark 2 DONE for parseStringWithMode in 6.086022375s
Benchmark 3 DONE for parseStringWithMode in 5.823671166s
Benchmark 4 DONE for parseStringWithMode in 5.786276500s
Preparing for add (warmup)
Benchmarking for add
Benchmark 0 DONE for add in 5.385408584s
Benchmark 1 DONE for add in 5.359253500s
Benchmark 2 DONE for add in 5.217283916s
Benchmark 3 DONE for add in 5.213005542s
Benchmark 4 DONE for add in 5.226768917s
Preparing for subtract (warmup)
Benchmarking for subtract
Benchmark 0 DONE for subtract in 4.833749708s
Benchmark 1 DONE for subtract in 4.737383542s
Benchmark 2 DONE for subtract in 4.668813250s
Benchmark 3 DONE for subtract in 4.795859792s
Benchmark 4 DONE for subtract in 4.706975333s
Preparing for multiply (warmup)
Benchmarking for multiply
Benchmark 0 DONE for multiply in 4.289741750s
Benchmark 1 DONE for multiply in 4.164642250s
Benchmark 2 DONE for multiply in 4.114723625s
Benchmark 3 DONE for multiply in 4.065344458s
Benchmark 4 DONE for multiply in 4.604802333s
Preparing for divide (warmup)
Benchmarking for divide
Benchmark 0 DONE for divide in 16.007358750s
Benchmark 1 DONE for divide in 16.290671208s
Benchmark 2 DONE for divide in 16.348688791s
Benchmark 3 DONE for divide in 16.214174333s
Benchmark 4 DONE for divide in 16.129669125s
Preparing for hashCode (warmup)
Benchmarking for hashCode
Benchmark 0 DONE for hashCode in 2.248416375s
Benchmark 1 DONE for hashCode in 2.144754208s
Benchmark 2 DONE for hashCode in 2.121003708s
Benchmark 3 DONE for hashCode in 2.110207208s
Benchmark 4 DONE for hashCode in 2.115298583s
Preparing for toStringExpanded (warmup)
Benchmarking for toStringExpanded
Benchmark 0 DONE for toStringExpanded in 3.154393917s
Benchmark 1 DONE for toStringExpanded in 3.135770167s
Benchmark 2 DONE for toStringExpanded in 3.125461583s
Benchmark 3 DONE for toStringExpanded in 3.122853042s
Benchmark 4 DONE for toStringExpanded in 3.127719417s
Preparing for toPlainString (warmup)
Benchmarking for toPlainString
Benchmark 0 DONE for toPlainString in 3.221781750s
Benchmark 1 DONE for toPlainString in 3.279738458s
Benchmark 2 DONE for toPlainString in 3.269062042s
Benchmark 3 DONE for toPlainString in 3.242374834s
Benchmark 4 DONE for toPlainString in 3.361823833s
Preparing for roundToDigitPosition (warmup)
Benchmarking for roundToDigitPosition
Benchmark 0 DONE for roundToDigitPosition in 4.082506875s
Benchmark 1 DONE for roundToDigitPosition in 4.087423667s
Benchmark 2 DONE for roundToDigitPosition in 4.323030167s
Benchmark 3 DONE for roundToDigitPosition in 4.081716666s
Benchmark 4 DONE for roundToDigitPosition in 4.076284833s
Preparing for pow (warmup)
Benchmarking for pow
Benchmark 0 DONE for pow in 8.825030750s
Benchmark 1 DONE for pow in 8.786915709s
Benchmark 2 DONE for pow in 8.720024125s
Benchmark 3 DONE for pow in 8.677275042s
Benchmark 4 DONE for pow in 8.600209875s
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| add |  5.385408584s | 5.359253500s | 5.217283916s | 5.213005542s | 5.226768917s  | 5.280344091s |
| divide |  16.007358750s | 16.290671208s | 16.348688791s | 16.214174333s | 16.129669125s  | 16.198112441s |
| hashCode |  2.248416375s | 2.144754208s | 2.121003708s | 2.110207208s | 2.115298583s  | 2.147936016s |
| multiply |  4.289741750s | 4.164642250s | 4.114723625s | 4.065344458s | 4.604802333s  | 4.247850883s |
| parseStringWithMode |  5.871168875s | 5.817717417s | 6.086022375s | 5.823671166s | 5.786276500s  | 5.876971266s |
| pow |  8.825030750s | 8.786915709s | 8.720024125s | 8.677275042s | 8.600209875s  | 8.721891100s |
| roundToDigitPosition |  4.082506875s | 4.087423667s | 4.323030167s | 4.081716666s | 4.076284833s  | 4.130192441s |
| subtract |  4.833749708s | 4.737383542s | 4.668813250s | 4.795859792s | 4.706975333s  | 4.748556325s |
| toPlainString |  3.221781750s | 3.279738458s | 3.269062042s | 3.242374834s | 3.361823833s  | 3.274956183s |
| toStringExpanded |  3.154393917s | 3.135770167s | 3.125461583s | 3.122853042s | 3.127719417s  | 3.133239625s |


-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- after 3rd commit 025a77465a7da03bc2d4f9df8024f1539e57db34


Preparing for parseStringWithMode (warmup)
Benchmarking for parseStringWithMode
Benchmark 0 DONE for parseStringWithMode in 5.962909500s
Benchmark 1 DONE for parseStringWithMode in 5.879412792s
Benchmark 2 DONE for parseStringWithMode in 5.981781583s
Benchmark 3 DONE for parseStringWithMode in 5.899648292s
Benchmark 4 DONE for parseStringWithMode in 5.923697917s
Preparing for add (warmup)
Benchmarking for add
Benchmark 0 DONE for add in 5.435422292s
Benchmark 1 DONE for add in 5.492117917s
Benchmark 2 DONE for add in 5.418271250s
Benchmark 3 DONE for add in 5.384207958s
Benchmark 4 DONE for add in 5.309335208s
Preparing for subtract (warmup)
Benchmarking for subtract
Benchmark 0 DONE for subtract in 5.068563625s
Benchmark 1 DONE for subtract in 4.885288833s
Benchmark 2 DONE for subtract in 4.796286s
Benchmark 3 DONE for subtract in 4.917022458s
Benchmark 4 DONE for subtract in 4.777188125s
Preparing for multiply (warmup)
Benchmarking for multiply
Benchmark 0 DONE for multiply in 4.233069167s
Benchmark 1 DONE for multiply in 4.212958458s
Benchmark 2 DONE for multiply in 4.212513125s
Benchmark 3 DONE for multiply in 4.230453625s
Benchmark 4 DONE for multiply in 4.185100459s
Preparing for divide (warmup)
Benchmarking for divide
Benchmark 0 DONE for divide in 16.158979458s
Benchmark 1 DONE for divide in 16.077749s
Benchmark 2 DONE for divide in 16.256035583s
Benchmark 3 DONE for divide in 16.137719667s
Benchmark 4 DONE for divide in 16.035147041s
Preparing for hashCode (warmup)
Benchmarking for hashCode
Benchmark 0 DONE for hashCode in 2.037175958s
Benchmark 1 DONE for hashCode in 2.095293416s
Benchmark 2 DONE for hashCode in 2.011758750s
Benchmark 3 DONE for hashCode in 1.999053083s
Benchmark 4 DONE for hashCode in 2.009785958s
Preparing for toStringExpanded (warmup)
Benchmarking for toStringExpanded
Benchmark 0 DONE for toStringExpanded in 3.206883875s
Benchmark 1 DONE for toStringExpanded in 3.205201916s
Benchmark 2 DONE for toStringExpanded in 3.372421625s
Benchmark 3 DONE for toStringExpanded in 3.204819125s
Benchmark 4 DONE for toStringExpanded in 3.175107s
Preparing for toPlainString (warmup)
Benchmarking for toPlainString
Benchmark 0 DONE for toPlainString in 3.276761500s
Benchmark 1 DONE for toPlainString in 3.318301750s
Benchmark 2 DONE for toPlainString in 3.604505417s
Benchmark 3 DONE for toPlainString in 3.422065917s
Benchmark 4 DONE for toPlainString in 3.557957958s
Preparing for roundToDigitPosition (warmup)
Benchmarking for roundToDigitPosition
Benchmark 0 DONE for roundToDigitPosition in 4.028694209s
Benchmark 1 DONE for roundToDigitPosition in 4.146693625s
Benchmark 2 DONE for roundToDigitPosition in 3.875029625s
Benchmark 3 DONE for roundToDigitPosition in 3.903158042s
Benchmark 4 DONE for roundToDigitPosition in 3.845113625s
Preparing for pow (warmup)
Benchmarking for pow
Benchmark 0 DONE for pow in 9.133553458s
Benchmark 1 DONE for pow in 9.139799458s
Benchmark 2 DONE for pow in 8.944042083s
Benchmark 3 DONE for pow in 9.104886416s
Benchmark 4 DONE for pow in 9.017410458s
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| add |  5.435422292s | 5.492117917s | 5.418271250s | 5.384207958s | 5.309335208s  | 5.407870925s |
| divide |  16.158979458s | 16.077749s | 16.256035583s | 16.137719667s | 16.035147041s  | 16.133126149s |
| hashCode |  2.037175958s | 2.095293416s | 2.011758750s | 1.999053083s | 2.009785958s  | 2.030613433s |
| multiply |  4.233069167s | 4.212958458s | 4.212513125s | 4.230453625s | 4.185100459s  | 4.214818966s |
| parseStringWithMode |  5.962909500s | 5.879412792s | 5.981781583s | 5.899648292s | 5.923697917s  | 5.929490016s |
| pow |  9.133553458s | 9.139799458s | 8.944042083s | 9.104886416s | 9.017410458s  | 9.067938374s |
| roundToDigitPosition |  4.028694209s | 4.146693625s | 3.875029625s | 3.903158042s | 3.845113625s  | 3.959737825s |
| subtract |  5.068563625s | 4.885288833s | 4.796286s | 4.917022458s | 4.777188125s  | 4.888869808s |
| toPlainString |  3.276761500s | 3.318301750s | 3.604505417s | 3.422065917s | 3.557957958s  | 3.435918508s |
| toStringExpanded |  3.206883875s | 3.205201916s | 3.372421625s | 3.204819125s | 3.175107s  | 3.232886708s |


-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- added bench for BigInteger.pow as it's quite often used in BigDecimal and new optimisation was visible


Preparing for BigInteger.pow (warmup)
Benchmarking for BigInteger.pow
Benchmark 0 DONE for BigInteger.pow in 708.251459ms
Benchmark 1 DONE for BigInteger.pow in 591.040042ms
Benchmark 2 DONE for BigInteger.pow in 570.373833ms
Benchmark 3 DONE for BigInteger.pow in 580.99ms
Benchmark 4 DONE for BigInteger.pow in 624.287541ms
Preparing for BigInteger.TEN.pow (warmup)
Benchmarking for BigInteger.TEN.pow
Benchmark 0 DONE for BigInteger.TEN.pow in 197.760459ms
Benchmark 1 DONE for BigInteger.TEN.pow in 172.682916ms
Benchmark 2 DONE for BigInteger.TEN.pow in 171.538708ms
Benchmark 3 DONE for BigInteger.TEN.pow in 181.152167ms
Benchmark 4 DONE for BigInteger.TEN.pow in 174.212041ms
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| BigInteger.TEN.pow |  197.760459ms | 172.682916ms | 171.538708ms | 181.152167ms | 174.212041ms  | 179.469258ms |
| BigInteger.pow |  708.251459ms | 591.040042ms | 570.373833ms | 580.99ms | 624.287541ms  | 614.988575ms |

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- after 5th commit 387c80aa7fc8c036471a1f473149e37b680fc645

Preparing for BigDecimal.parseStringWithMode (warmup)
Benchmarking for BigDecimal.parseStringWithMode
Benchmark 0 DONE for BigDecimal.parseStringWithMode in 6.059477250s
Benchmark 1 DONE for BigDecimal.parseStringWithMode in 5.629839917s
Benchmark 2 DONE for BigDecimal.parseStringWithMode in 5.843753042s
Benchmark 3 DONE for BigDecimal.parseStringWithMode in 5.600076750s
Benchmark 4 DONE for BigDecimal.parseStringWithMode in 5.584958917s
Preparing for BigDecimal.add (warmup)
Benchmarking for BigDecimal.add
Benchmark 0 DONE for BigDecimal.add in 4.776145333s
Benchmark 1 DONE for BigDecimal.add in 4.713696875s
Benchmark 2 DONE for BigDecimal.add in 4.761352375s
Benchmark 3 DONE for BigDecimal.add in 4.794728333s
Benchmark 4 DONE for BigDecimal.add in 4.972099500s
Preparing for BigDecimal.subtract (warmup)
Benchmarking for BigDecimal.subtract
Benchmark 0 DONE for BigDecimal.subtract in 4.348947542s
Benchmark 1 DONE for BigDecimal.subtract in 4.234030875s
Benchmark 2 DONE for BigDecimal.subtract in 4.263835292s
Benchmark 3 DONE for BigDecimal.subtract in 4.185889500s
Benchmark 4 DONE for BigDecimal.subtract in 4.142205125s
Preparing for BigDecimal.multiply (warmup)
Benchmarking for BigDecimal.multiply
Benchmark 0 DONE for BigDecimal.multiply in 4.053102583s
Benchmark 1 DONE for BigDecimal.multiply in 4.183711s
Benchmark 2 DONE for BigDecimal.multiply in 4.071748208s
Benchmark 3 DONE for BigDecimal.multiply in 4.082529250s
Benchmark 4 DONE for BigDecimal.multiply in 4.028866959s
Preparing for BigDecimal.divide (warmup)
Benchmarking for BigDecimal.divide
Benchmark 0 DONE for BigDecimal.divide in 15.147878458s
Benchmark 1 DONE for BigDecimal.divide in 16.285589s
Benchmark 2 DONE for BigDecimal.divide in 15.658380333s
Benchmark 3 DONE for BigDecimal.divide in 15.156500542s
Benchmark 4 DONE for BigDecimal.divide in 15.186437792s
Preparing for BigDecimal.hashCode (warmup)
Benchmarking for BigDecimal.hashCode
Benchmark 0 DONE for BigDecimal.hashCode in 1.946938625s
Benchmark 1 DONE for BigDecimal.hashCode in 1.958095750s
Benchmark 2 DONE for BigDecimal.hashCode in 1.973294792s
Benchmark 3 DONE for BigDecimal.hashCode in 1.986948667s
Benchmark 4 DONE for BigDecimal.hashCode in 1.932702750s
Preparing for BigDecimal.toStringExpanded (warmup)
Benchmarking for BigDecimal.toStringExpanded
Benchmark 0 DONE for BigDecimal.toStringExpanded in 3.067445417s
Benchmark 1 DONE for BigDecimal.toStringExpanded in 3.087867709s
Benchmark 2 DONE for BigDecimal.toStringExpanded in 3.093053417s
Benchmark 3 DONE for BigDecimal.toStringExpanded in 3.104182292s
Benchmark 4 DONE for BigDecimal.toStringExpanded in 3.136935083s
Preparing for BigDecimal.toPlainString (warmup)
Benchmarking for BigDecimal.toPlainString
Benchmark 0 DONE for BigDecimal.toPlainString in 3.227157500s
Benchmark 1 DONE for BigDecimal.toPlainString in 3.238327875s
Benchmark 2 DONE for BigDecimal.toPlainString in 3.186606709s
Benchmark 3 DONE for BigDecimal.toPlainString in 3.203691708s
Benchmark 4 DONE for BigDecimal.toPlainString in 3.290697459s
Preparing for BigDecimal.roundToDigitPosition (warmup)
Benchmarking for BigDecimal.roundToDigitPosition
Benchmark 0 DONE for BigDecimal.roundToDigitPosition in 3.502337792s
Benchmark 1 DONE for BigDecimal.roundToDigitPosition in 3.472156041s
Benchmark 2 DONE for BigDecimal.roundToDigitPosition in 3.445331833s
Benchmark 3 DONE for BigDecimal.roundToDigitPosition in 3.466756167s
Benchmark 4 DONE for BigDecimal.roundToDigitPosition in 3.479745500s
Preparing for BigDecimal.pow (warmup)
Benchmarking for BigDecimal.pow
Benchmark 0 DONE for BigDecimal.pow in 8.691567042s
Benchmark 1 DONE for BigDecimal.pow in 8.684460667s
Benchmark 2 DONE for BigDecimal.pow in 8.630949459s
Benchmark 3 DONE for BigDecimal.pow in 8.663292291s
Benchmark 4 DONE for BigDecimal.pow in 8.613886125s
Preparing for BigInteger.pow (warmup)
Benchmarking for BigInteger.pow
Benchmark 0 DONE for BigInteger.pow in 617.09ms
Benchmark 1 DONE for BigInteger.pow in 606.461458ms
Benchmark 2 DONE for BigInteger.pow in 625.646917ms
Benchmark 3 DONE for BigInteger.pow in 625.241708ms
Benchmark 4 DONE for BigInteger.pow in 642.403500ms
Preparing for BigInteger.TEN.pow (warmup)
Benchmarking for BigInteger.TEN.pow
Benchmark 0 DONE for BigInteger.TEN.pow in 118.757500ms
Benchmark 1 DONE for BigInteger.TEN.pow in 120.086666ms
Benchmark 2 DONE for BigInteger.TEN.pow in 118.946500ms
Benchmark 3 DONE for BigInteger.TEN.pow in 125.895625ms
Benchmark 4 DONE for BigInteger.TEN.pow in 120.406833ms
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| BigDecimal.add |  4.776145333s | 4.713696875s | 4.761352375s | 4.794728333s | 4.972099500s  | 4.803604483s |
| BigDecimal.divide |  15.147878458s | 16.285589s | 15.658380333s | 15.156500542s | 15.186437792s  | 15.486957225s |
| BigDecimal.hashCode |  1.946938625s | 1.958095750s | 1.973294792s | 1.986948667s | 1.932702750s  | 1.959596116s |
| BigDecimal.multiply |  4.053102583s | 4.183711s | 4.071748208s | 4.082529250s | 4.028866959s  | 4.083991600s |
| BigDecimal.parseStringWithMode |  6.059477250s | 5.629839917s | 5.843753042s | 5.600076750s | 5.584958917s  | 5.743621175s |
| BigDecimal.pow |  8.691567042s | 8.684460667s | 8.630949459s | 8.663292291s | 8.613886125s  | 8.656831116s |
| BigDecimal.roundToDigitPosition |  3.502337792s | 3.472156041s | 3.445331833s | 3.466756167s | 3.479745500s  | 3.473265466s |
| BigDecimal.subtract |  4.348947542s | 4.234030875s | 4.263835292s | 4.185889500s | 4.142205125s  | 4.234981666s |
| BigDecimal.toPlainString |  3.227157500s | 3.238327875s | 3.186606709s | 3.203691708s | 3.290697459s  | 3.229296250s |
| BigDecimal.toStringExpanded |  3.067445417s | 3.087867709s | 3.093053417s | 3.104182292s | 3.136935083s  | 3.097896783s |
| BigInteger.TEN.pow |  118.757500ms | 120.086666ms | 118.946500ms | 125.895625ms | 120.406833ms  | 120.818624ms |
| BigInteger.pow |  617.09ms | 606.461458ms | 625.646917ms | 625.241708ms | 642.403500ms  | 623.368716ms |


-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- after commit a62411e5f1e5332baa977066cbd0261a1a799e0c

Preparing for BigDecimal.parseStringWithMode (warmup)
Benchmarking for BigDecimal.parseStringWithMode
Benchmark 0 DONE for BigDecimal.parseStringWithMode in 2.698611041s
Benchmark 1 DONE for BigDecimal.parseStringWithMode in 2.600751458s
Benchmark 2 DONE for BigDecimal.parseStringWithMode in 2.592591416s
Benchmark 3 DONE for BigDecimal.parseStringWithMode in 2.594812583s
Benchmark 4 DONE for BigDecimal.parseStringWithMode in 2.624011792s
Preparing for BigDecimal.isZero (warmup)
Benchmarking for BigDecimal.isZero
Benchmark 0 DONE for BigDecimal.isZero in 257.937750ms
Benchmark 1 DONE for BigDecimal.isZero in 284.250584ms
Benchmark 2 DONE for BigDecimal.isZero in 284.132708ms
Benchmark 3 DONE for BigDecimal.isZero in 80.903792ms
Benchmark 4 DONE for BigDecimal.isZero in 281.913041ms
Preparing for BigInteger.isZero (warmup)
Benchmarking for BigInteger.isZero
Benchmark 0 DONE for BigInteger.isZero in 61.531916ms
Benchmark 1 DONE for BigInteger.isZero in 29.997042ms
Benchmark 2 DONE for BigInteger.isZero in 30.218875ms
Benchmark 3 DONE for BigInteger.isZero in 29.845875ms
Benchmark 4 DONE for BigInteger.isZero in 30.305208ms
Preparing for BigDecimal.add (warmup)
Benchmarking for BigDecimal.add
Benchmark 0 DONE for BigDecimal.add in 4.782700625s
Benchmark 1 DONE for BigDecimal.add in 4.783740333s
Benchmark 2 DONE for BigDecimal.add in 4.718808417s
Benchmark 3 DONE for BigDecimal.add in 4.800132417s
Benchmark 4 DONE for BigDecimal.add in 4.777836292s
Preparing for BigDecimal.subtract (warmup)
Benchmarking for BigDecimal.subtract
Benchmark 0 DONE for BigDecimal.subtract in 4.304243750s
Benchmark 1 DONE for BigDecimal.subtract in 4.165261875s
Benchmark 2 DONE for BigDecimal.subtract in 4.169642083s
Benchmark 3 DONE for BigDecimal.subtract in 4.175906167s
Benchmark 4 DONE for BigDecimal.subtract in 4.360043417s
Preparing for BigDecimal.multiply (warmup)
Benchmarking for BigDecimal.multiply
Benchmark 0 DONE for BigDecimal.multiply in 4.104828375s
Benchmark 1 DONE for BigDecimal.multiply in 4.072347916s
Benchmark 2 DONE for BigDecimal.multiply in 4.071960625s
Benchmark 3 DONE for BigDecimal.multiply in 4.032605500s
Benchmark 4 DONE for BigDecimal.multiply in 4.140784292s
Preparing for BigDecimal.divide (warmup)
Benchmarking for BigDecimal.divide
Benchmark 0 DONE for BigDecimal.divide in 15.544811375s
Benchmark 1 DONE for BigDecimal.divide in 16.048308792s
Benchmark 2 DONE for BigDecimal.divide in 16.049432417s
Benchmark 3 DONE for BigDecimal.divide in 15.703990750s
Benchmark 4 DONE for BigDecimal.divide in 15.810308917s
Preparing for BigDecimal.hashCode (warmup)
Benchmarking for BigDecimal.hashCode
Benchmark 0 DONE for BigDecimal.hashCode in 2.031215458s
Benchmark 1 DONE for BigDecimal.hashCode in 2.011608750s
Benchmark 2 DONE for BigDecimal.hashCode in 2.001733666s
Benchmark 3 DONE for BigDecimal.hashCode in 2.040233083s
Benchmark 4 DONE for BigDecimal.hashCode in 2.111728084s
Preparing for BigDecimal.toStringExpanded (warmup)
Benchmarking for BigDecimal.toStringExpanded
Benchmark 0 DONE for BigDecimal.toStringExpanded in 3.174595292s
Benchmark 1 DONE for BigDecimal.toStringExpanded in 3.111445375s
Benchmark 2 DONE for BigDecimal.toStringExpanded in 3.156344083s
Benchmark 3 DONE for BigDecimal.toStringExpanded in 3.212045917s
Benchmark 4 DONE for BigDecimal.toStringExpanded in 3.136060042s
Preparing for BigDecimal.toPlainString (warmup)
Benchmarking for BigDecimal.toPlainString
Benchmark 0 DONE for BigDecimal.toPlainString in 3.276869708s
Benchmark 1 DONE for BigDecimal.toPlainString in 3.419209500s
Benchmark 2 DONE for BigDecimal.toPlainString in 3.276027916s
Benchmark 3 DONE for BigDecimal.toPlainString in 3.283144792s
Benchmark 4 DONE for BigDecimal.toPlainString in 3.290408500s
Preparing for BigDecimal.roundToDigitPosition (warmup)
Benchmarking for BigDecimal.roundToDigitPosition
Benchmark 0 DONE for BigDecimal.roundToDigitPosition in 3.532772666s
Benchmark 1 DONE for BigDecimal.roundToDigitPosition in 3.475761250s
Benchmark 2 DONE for BigDecimal.roundToDigitPosition in 3.476933208s
Benchmark 3 DONE for BigDecimal.roundToDigitPosition in 3.547324791s
Benchmark 4 DONE for BigDecimal.roundToDigitPosition in 3.511297s
Preparing for BigDecimal.pow (warmup)
Benchmarking for BigDecimal.pow
Benchmark 0 DONE for BigDecimal.pow in 8.702263875s
Benchmark 1 DONE for BigDecimal.pow in 9.431212250s
Benchmark 2 DONE for BigDecimal.pow in 8.804831333s
Benchmark 3 DONE for BigDecimal.pow in 8.978058542s
Benchmark 4 DONE for BigDecimal.pow in 9.302447833s
Preparing for BigInteger.pow (warmup)
Benchmarking for BigInteger.pow
Benchmark 0 DONE for BigInteger.pow in 640.873500ms
Benchmark 1 DONE for BigInteger.pow in 636.114333ms
Benchmark 2 DONE for BigInteger.pow in 618.318833ms
Benchmark 3 DONE for BigInteger.pow in 620.655542ms
Benchmark 4 DONE for BigInteger.pow in 647.127625ms
Preparing for BigInteger.TEN.pow (warmup)
Benchmarking for BigInteger.TEN.pow
Benchmark 0 DONE for BigInteger.TEN.pow in 122.074209ms
Benchmark 1 DONE for BigInteger.TEN.pow in 126.743541ms
Benchmark 2 DONE for BigInteger.TEN.pow in 124.553125ms
Benchmark 3 DONE for BigInteger.TEN.pow in 126.389ms
Benchmark 4 DONE for BigInteger.TEN.pow in 125.902584ms
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| BigDecimal.add |  4.782700625s | 4.783740333s | 4.718808417s | 4.800132417s | 4.777836292s  | 4.772643616s |
| BigDecimal.divide |  15.544811375s | 16.048308792s | 16.049432417s | 15.703990750s | 15.810308917s  | 15.831370450s |
| BigDecimal.hashCode |  2.031215458s | 2.011608750s | 2.001733666s | 2.040233083s | 2.111728084s  | 2.039303808s |
| BigDecimal.isZero |  257.937750ms | 284.250584ms | 284.132708ms | 80.903792ms | 281.913041ms  | 237.827575ms |
| BigDecimal.multiply |  4.104828375s | 4.072347916s | 4.071960625s | 4.032605500s | 4.140784292s  | 4.084505341s |
| BigDecimal.parseStringWithMode |  2.698611041s | 2.600751458s | 2.592591416s | 2.594812583s | 2.624011792s  | 2.622155658s |
| BigDecimal.pow |  8.702263875s | 9.431212250s | 8.804831333s | 8.978058542s | 9.302447833s  | 9.043762766s |
| BigDecimal.roundToDigitPosition |  3.532772666s | 3.475761250s | 3.476933208s | 3.547324791s | 3.511297s  | 3.508817783s |
| BigDecimal.subtract |  4.304243750s | 4.165261875s | 4.169642083s | 4.175906167s | 4.360043417s  | 4.235019458s |
| BigDecimal.toPlainString |  3.276869708s | 3.419209500s | 3.276027916s | 3.283144792s | 3.290408500s  | 3.309132083s |
| BigDecimal.toStringExpanded |  3.174595292s | 3.111445375s | 3.156344083s | 3.212045917s | 3.136060042s  | 3.158098141s |
| BigInteger.TEN.pow |  122.074209ms | 126.743541ms | 124.553125ms | 126.389ms | 125.902584ms  | 125.132491ms |
| BigInteger.isZero |  61.531916ms | 29.997042ms | 30.218875ms | 29.845875ms | 30.305208ms  | 36.379783ms |
| BigInteger.pow |  640.873500ms | 636.114333ms | 618.318833ms | 620.655542ms | 647.127625ms  | 632.617966ms |



-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- after commit a0ff760cfd72c4a6d561608be0fb202ea89fb8c6

Preparing for BigDecimal.parseStringWithMode (warmup)
Benchmarking for BigDecimal.parseStringWithMode
Benchmark 0 DONE for BigDecimal.parseStringWithMode in 2.595658583s
Benchmark 1 DONE for BigDecimal.parseStringWithMode in 2.317404584s
Benchmark 2 DONE for BigDecimal.parseStringWithMode in 2.319967250s
Benchmark 3 DONE for BigDecimal.parseStringWithMode in 2.319874958s
Benchmark 4 DONE for BigDecimal.parseStringWithMode in 2.444415167s
Preparing for BigDecimal.add (warmup)
Benchmarking for BigDecimal.add
Benchmark 0 DONE for BigDecimal.add in 4.821683875s
Benchmark 1 DONE for BigDecimal.add in 4.646818875s
Benchmark 2 DONE for BigDecimal.add in 4.867108416s
Benchmark 3 DONE for BigDecimal.add in 4.637809458s
Benchmark 4 DONE for BigDecimal.add in 4.626659167s
Preparing for BigDecimal.subtract (warmup)
Benchmarking for BigDecimal.subtract
Benchmark 0 DONE for BigDecimal.subtract in 4.012933s
Benchmark 1 DONE for BigDecimal.subtract in 3.916905833s
Benchmark 2 DONE for BigDecimal.subtract in 3.918102750s
Benchmark 3 DONE for BigDecimal.subtract in 4.008240584s
Benchmark 4 DONE for BigDecimal.subtract in 3.940535042s
Preparing for BigDecimal.multiply (warmup)
Benchmarking for BigDecimal.multiply
Benchmark 0 DONE for BigDecimal.multiply in 3.722194666s
Benchmark 1 DONE for BigDecimal.multiply in 3.688849417s
Benchmark 2 DONE for BigDecimal.multiply in 3.683564917s
Benchmark 3 DONE for BigDecimal.multiply in 3.720415708s
Benchmark 4 DONE for BigDecimal.multiply in 3.740217625s
Preparing for BigDecimal.divide (warmup)
Benchmarking for BigDecimal.divide
Benchmark 0 DONE for BigDecimal.divide in 14.948320958s
Benchmark 1 DONE for BigDecimal.divide in 14.571104833s
Benchmark 2 DONE for BigDecimal.divide in 15.248688791s
Benchmark 3 DONE for BigDecimal.divide in 14.694409459s
Benchmark 4 DONE for BigDecimal.divide in 14.724529458s
Preparing for BigDecimal.hashCode (warmup)
Benchmarking for BigDecimal.hashCode
Benchmark 0 DONE for BigDecimal.hashCode in 1.941280125s
Benchmark 1 DONE for BigDecimal.hashCode in 1.927224709s
Benchmark 2 DONE for BigDecimal.hashCode in 1.918954833s
Benchmark 3 DONE for BigDecimal.hashCode in 1.906742834s
Benchmark 4 DONE for BigDecimal.hashCode in 1.893762959s
Preparing for BigDecimal.toStringExpanded (warmup)
Benchmarking for BigDecimal.toStringExpanded
Benchmark 0 DONE for BigDecimal.toStringExpanded in 3.058942584s
Benchmark 1 DONE for BigDecimal.toStringExpanded in 3.053817417s
Benchmark 2 DONE for BigDecimal.toStringExpanded in 3.105085167s
Benchmark 3 DONE for BigDecimal.toStringExpanded in 3.096185750s
Benchmark 4 DONE for BigDecimal.toStringExpanded in 3.062524459s
Preparing for BigDecimal.toPlainString (warmup)
Benchmarking for BigDecimal.toPlainString
Benchmark 0 DONE for BigDecimal.toPlainString in 3.207647458s
Benchmark 1 DONE for BigDecimal.toPlainString in 3.221871334s
Benchmark 2 DONE for BigDecimal.toPlainString in 3.283931625s
Benchmark 3 DONE for BigDecimal.toPlainString in 3.162143500s
Benchmark 4 DONE for BigDecimal.toPlainString in 3.155379208s
Preparing for BigDecimal.roundToDigitPosition (warmup)
Benchmarking for BigDecimal.roundToDigitPosition
Benchmark 0 DONE for BigDecimal.roundToDigitPosition in 3.323082333s
Benchmark 1 DONE for BigDecimal.roundToDigitPosition in 3.680744833s
Benchmark 2 DONE for BigDecimal.roundToDigitPosition in 3.289028375s
Benchmark 3 DONE for BigDecimal.roundToDigitPosition in 3.431909958s
Benchmark 4 DONE for BigDecimal.roundToDigitPosition in 3.367676709s
Preparing for BigDecimal.pow (warmup)
Benchmarking for BigDecimal.pow
Benchmark 0 DONE for BigDecimal.pow in 8.859913542s
Benchmark 1 DONE for BigDecimal.pow in 8.576593208s
Benchmark 2 DONE for BigDecimal.pow in 8.556922875s
Benchmark 3 DONE for BigDecimal.pow in 8.249520542s
Benchmark 4 DONE for BigDecimal.pow in 8.276381542s
Preparing for BigDecimal.isZero (warmup)
Benchmarking for BigDecimal.isZero
Benchmark 0 DONE for BigDecimal.isZero in 43.312541ms
Benchmark 1 DONE for BigDecimal.isZero in 39.069291ms
Benchmark 2 DONE for BigDecimal.isZero in 41.516083ms
Benchmark 3 DONE for BigDecimal.isZero in 44.547416ms
Benchmark 4 DONE for BigDecimal.isZero in 48.018583ms
Preparing for BigInteger.pow (warmup)
Benchmarking for BigInteger.pow
Benchmark 0 DONE for BigInteger.pow in 549.895750ms
Benchmark 1 DONE for BigInteger.pow in 524.238417ms
Benchmark 2 DONE for BigInteger.pow in 539.626792ms
Benchmark 3 DONE for BigInteger.pow in 563.92ms
Benchmark 4 DONE for BigInteger.pow in 521.503750ms
Preparing for BigInteger.TEN.pow (warmup)
Benchmarking for BigInteger.TEN.pow
Benchmark 0 DONE for BigInteger.TEN.pow in 130.528542ms
Benchmark 1 DONE for BigInteger.TEN.pow in 131.713083ms
Benchmark 2 DONE for BigInteger.TEN.pow in 131.781958ms
Benchmark 3 DONE for BigInteger.TEN.pow in 131.065459ms
Benchmark 4 DONE for BigInteger.TEN.pow in 131.950250ms
Preparing for BigInteger.isZero (warmup)
Benchmarking for BigInteger.isZero
Benchmark 0 DONE for BigInteger.isZero in 31.437958ms
Benchmark 1 DONE for BigInteger.isZero in 31.383209ms
Benchmark 2 DONE for BigInteger.isZero in 31.317291ms
Benchmark 3 DONE for BigInteger.isZero in 31.350500ms
Benchmark 4 DONE for BigInteger.isZero in 31.534083ms
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| BigDecimal.add |  4.821683875s | 4.646818875s | 4.867108416s | 4.637809458s | 4.626659167s  | 4.720015958s |
| BigDecimal.divide |  14.948320958s | 14.571104833s | 15.248688791s | 14.694409459s | 14.724529458s  | 14.837410699s |
| BigDecimal.hashCode |  1.941280125s | 1.927224709s | 1.918954833s | 1.906742834s | 1.893762959s  | 1.917593092s |
| BigDecimal.isZero |  43.312541ms | 39.069291ms | 41.516083ms | 44.547416ms | 48.018583ms  | 43.292782ms |
| BigDecimal.multiply |  3.722194666s | 3.688849417s | 3.683564917s | 3.720415708s | 3.740217625s  | 3.711048466s |
| BigDecimal.parseStringWithMode |  2.595658583s | 2.317404584s | 2.319967250s | 2.319874958s | 2.444415167s  | 2.399464108s |
| BigDecimal.pow |  8.859913542s | 8.576593208s | 8.556922875s | 8.249520542s | 8.276381542s  | 8.503866341s |
| BigDecimal.roundToDigitPosition |  3.323082333s | 3.680744833s | 3.289028375s | 3.431909958s | 3.367676709s  | 3.418488441s |
| BigDecimal.subtract |  4.012933s | 3.916905833s | 3.918102750s | 4.008240584s | 3.940535042s  | 3.959343441s |
| BigDecimal.toPlainString |  3.207647458s | 3.221871334s | 3.283931625s | 3.162143500s | 3.155379208s  | 3.206194625s |
| BigDecimal.toStringExpanded |  3.058942584s | 3.053817417s | 3.105085167s | 3.096185750s | 3.062524459s  | 3.075311075s |
| BigInteger.TEN.pow |  130.528542ms | 131.713083ms | 131.781958ms | 131.065459ms | 131.950250ms  | 131.407858ms |
| BigInteger.isZero |  31.437958ms | 31.383209ms | 31.317291ms | 31.350500ms | 31.534083ms  | 31.404608ms |
| BigInteger.pow |  549.895750ms | 524.238417ms | 539.626792ms | 563.92ms | 521.503750ms  | 539.836941ms |




-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- after commit a0111a298ed1f3fd73a19b0cb05368c081e942ad


Preparing for BigDecimal.parseStringWithMode (warmup)
Benchmarking for BigDecimal.parseStringWithMode
Benchmark 0 DONE for BigDecimal.parseStringWithMode in 2.799018250s
Benchmark 1 DONE for BigDecimal.parseStringWithMode in 3.003082917s
Benchmark 2 DONE for BigDecimal.parseStringWithMode in 2.860970291s
Benchmark 3 DONE for BigDecimal.parseStringWithMode in 2.758880959s
Benchmark 4 DONE for BigDecimal.parseStringWithMode in 2.750851083s
Preparing for BigDecimal.add (warmup)
Benchmarking for BigDecimal.add
Benchmark 0 DONE for BigDecimal.add in 4.216615750s
Benchmark 1 DONE for BigDecimal.add in 4.398061125s
Benchmark 2 DONE for BigDecimal.add in 4.154919375s
Benchmark 3 DONE for BigDecimal.add in 4.197115833s
Benchmark 4 DONE for BigDecimal.add in 4.067613667s
Preparing for BigDecimal.subtract (warmup)
Benchmarking for BigDecimal.subtract
Benchmark 0 DONE for BigDecimal.subtract in 4.104830708s
Benchmark 1 DONE for BigDecimal.subtract in 4.014428958s
Benchmark 2 DONE for BigDecimal.subtract in 4.023570292s
Benchmark 3 DONE for BigDecimal.subtract in 4.030161291s
Benchmark 4 DONE for BigDecimal.subtract in 4.111443708s
Preparing for BigDecimal.multiply (warmup)
Benchmarking for BigDecimal.multiply
Benchmark 0 DONE for BigDecimal.multiply in 3.794947750s
Benchmark 1 DONE for BigDecimal.multiply in 3.745175875s
Benchmark 2 DONE for BigDecimal.multiply in 3.706602250s
Benchmark 3 DONE for BigDecimal.multiply in 3.746263917s
Benchmark 4 DONE for BigDecimal.multiply in 3.771436875s
Preparing for BigDecimal.divide (warmup)
Benchmarking for BigDecimal.divide
Benchmark 0 DONE for BigDecimal.divide in 14.371995542s
Benchmark 1 DONE for BigDecimal.divide in 14.635455500s
Benchmark 2 DONE for BigDecimal.divide in 14.689509292s
Benchmark 3 DONE for BigDecimal.divide in 15.184840584s
Benchmark 4 DONE for BigDecimal.divide in 15.123634375s
Preparing for BigDecimal.hashCode (warmup)
Benchmarking for BigDecimal.hashCode
Benchmark 0 DONE for BigDecimal.hashCode in 1.978604875s
Benchmark 1 DONE for BigDecimal.hashCode in 1.939047917s
Benchmark 2 DONE for BigDecimal.hashCode in 2.044111458s
Benchmark 3 DONE for BigDecimal.hashCode in 1.917777709s
Benchmark 4 DONE for BigDecimal.hashCode in 1.914771125s
Preparing for BigDecimal.toStringExpanded (warmup)
Benchmarking for BigDecimal.toStringExpanded
Benchmark 0 DONE for BigDecimal.toStringExpanded in 3.040580917s
Benchmark 1 DONE for BigDecimal.toStringExpanded in 3.195272833s
Benchmark 2 DONE for BigDecimal.toStringExpanded in 3.072737708s
Benchmark 3 DONE for BigDecimal.toStringExpanded in 3.115372458s
Benchmark 4 DONE for BigDecimal.toStringExpanded in 3.042401125s
Preparing for BigDecimal.toPlainString (warmup)
Benchmarking for BigDecimal.toPlainString
Benchmark 0 DONE for BigDecimal.toPlainString in 3.135506s
Benchmark 1 DONE for BigDecimal.toPlainString in 3.140246791s
Benchmark 2 DONE for BigDecimal.toPlainString in 3.170325083s
Benchmark 3 DONE for BigDecimal.toPlainString in 3.094552083s
Benchmark 4 DONE for BigDecimal.toPlainString in 3.065638750s
Preparing for BigDecimal.roundToDigitPosition (warmup)
Benchmarking for BigDecimal.roundToDigitPosition
Benchmark 0 DONE for BigDecimal.roundToDigitPosition in 3.081648667s
Benchmark 1 DONE for BigDecimal.roundToDigitPosition in 3.104941083s
Benchmark 2 DONE for BigDecimal.roundToDigitPosition in 3.110146500s
Benchmark 3 DONE for BigDecimal.roundToDigitPosition in 3.203495166s
Benchmark 4 DONE for BigDecimal.roundToDigitPosition in 3.110934750s
Preparing for BigDecimal.pow (warmup)
Benchmarking for BigDecimal.pow
Benchmark 0 DONE for BigDecimal.pow in 8.554452875s
Benchmark 1 DONE for BigDecimal.pow in 8.453042458s
Benchmark 2 DONE for BigDecimal.pow in 8.471056042s
Benchmark 3 DONE for BigDecimal.pow in 8.340219542s
Benchmark 4 DONE for BigDecimal.pow in 8.357847042s
Preparing for BigDecimal.isZero (warmup)
Benchmarking for BigDecimal.isZero
Benchmark 0 DONE for BigDecimal.isZero in 37.635875ms
Benchmark 1 DONE for BigDecimal.isZero in 43.174750ms
Benchmark 2 DONE for BigDecimal.isZero in 49.289750ms
Benchmark 3 DONE for BigDecimal.isZero in 41.095084ms
Benchmark 4 DONE for BigDecimal.isZero in 53.073542ms
Preparing for BigInteger.pow (warmup)
Benchmarking for BigInteger.pow
Benchmark 0 DONE for BigInteger.pow in 539.312667ms
Benchmark 1 DONE for BigInteger.pow in 523.481625ms
Benchmark 2 DONE for BigInteger.pow in 507.763916ms
Benchmark 3 DONE for BigInteger.pow in 506.165041ms
Benchmark 4 DONE for BigInteger.pow in 507.138ms
Preparing for BigInteger.TEN.pow (warmup)
Benchmarking for BigInteger.TEN.pow
Benchmark 0 DONE for BigInteger.TEN.pow in 144.528ms
Benchmark 1 DONE for BigInteger.TEN.pow in 119.338500ms
Benchmark 2 DONE for BigInteger.TEN.pow in 117.512417ms
Benchmark 3 DONE for BigInteger.TEN.pow in 117.586458ms
Benchmark 4 DONE for BigInteger.TEN.pow in 118.650458ms
Preparing for BigInteger.isZero (warmup)
Benchmarking for BigInteger.isZero
Benchmark 0 DONE for BigInteger.isZero in 31.552083ms
Benchmark 1 DONE for BigInteger.isZero in 31.826ms
Benchmark 2 DONE for BigInteger.isZero in 31.491709ms
Benchmark 3 DONE for BigInteger.isZero in 31.649167ms
Benchmark 4 DONE for BigInteger.isZero in 31.893500ms
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| BigDecimal.add |  4.216615750s | 4.398061125s | 4.154919375s | 4.197115833s | 4.067613667s  | 4.206865150s |
| BigDecimal.divide |  14.371995542s | 14.635455500s | 14.689509292s | 15.184840584s | 15.123634375s  | 14.801087058s |
| BigDecimal.hashCode |  1.978604875s | 1.939047917s | 2.044111458s | 1.917777709s | 1.914771125s  | 1.958862616s |
| BigDecimal.isZero |  37.635875ms | 43.174750ms | 49.289750ms | 41.095084ms | 53.073542ms  | 44.853800ms |
| BigDecimal.multiply |  3.794947750s | 3.745175875s | 3.706602250s | 3.746263917s | 3.771436875s  | 3.752885333s |
| BigDecimal.parseStringWithMode |  2.799018250s | 3.003082917s | 2.860970291s | 2.758880959s | 2.750851083s  | 2.834560700s |
| BigDecimal.pow |  8.554452875s | 8.453042458s | 8.471056042s | 8.340219542s | 8.357847042s  | 8.435323591s |
| BigDecimal.roundToDigitPosition |  3.081648667s | 3.104941083s | 3.110146500s | 3.203495166s | 3.110934750s  | 3.122233233s |
| BigDecimal.subtract |  4.104830708s | 4.014428958s | 4.023570292s | 4.030161291s | 4.111443708s  | 4.056886991s |
| BigDecimal.toPlainString |  3.135506s | 3.140246791s | 3.170325083s | 3.094552083s | 3.065638750s  | 3.121253741s |
| BigDecimal.toStringExpanded |  3.040580917s | 3.195272833s | 3.072737708s | 3.115372458s | 3.042401125s  | 3.093273008s |
| BigInteger.TEN.pow |  144.528ms | 119.338500ms | 117.512417ms | 117.586458ms | 118.650458ms  | 123.523166ms |
| BigInteger.isZero |  31.552083ms | 31.826ms | 31.491709ms | 31.649167ms | 31.893500ms  | 31.682491ms |
| BigInteger.pow |  539.312667ms | 523.481625ms | 507.763916ms | 506.165041ms | 507.138ms  | 516.772249ms |




-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- after commit f96e18c25322db2808f3003cc9f852b321a4c04b


Preparing for BigDecimal.parseStringWithMode (warmup)
Benchmarking for BigDecimal.parseStringWithMode
Benchmark 0 DONE for BigDecimal.parseStringWithMode in 2.847489542s
Benchmark 1 DONE for BigDecimal.parseStringWithMode in 2.801993041s
Benchmark 2 DONE for BigDecimal.parseStringWithMode in 2.737596042s
Benchmark 3 DONE for BigDecimal.parseStringWithMode in 2.727944292s
Benchmark 4 DONE for BigDecimal.parseStringWithMode in 2.862519750s
Preparing for BigDecimal.add (warmup)
Benchmarking for BigDecimal.add
Benchmark 0 DONE for BigDecimal.add in 3.756398666s
Benchmark 1 DONE for BigDecimal.add in 3.476847917s
Benchmark 2 DONE for BigDecimal.add in 3.471759167s
Benchmark 3 DONE for BigDecimal.add in 3.680526333s
Benchmark 4 DONE for BigDecimal.add in 3.744516542s
Preparing for BigDecimal.subtract (warmup)
Benchmarking for BigDecimal.subtract
Benchmark 0 DONE for BigDecimal.subtract in 3.532442291s
Benchmark 1 DONE for BigDecimal.subtract in 3.275783083s
Benchmark 2 DONE for BigDecimal.subtract in 3.332147292s
Benchmark 3 DONE for BigDecimal.subtract in 3.390437417s
Benchmark 4 DONE for BigDecimal.subtract in 3.284431833s
Preparing for BigDecimal.multiply (warmup)
Benchmarking for BigDecimal.multiply
Benchmark 0 DONE for BigDecimal.multiply in 4.121463166s
Benchmark 1 DONE for BigDecimal.multiply in 3.832564208s
Benchmark 2 DONE for BigDecimal.multiply in 3.858924375s
Benchmark 3 DONE for BigDecimal.multiply in 3.864766458s
Benchmark 4 DONE for BigDecimal.multiply in 3.799875833s
Preparing for BigDecimal.divide (warmup)
Benchmarking for BigDecimal.divide
Benchmark 0 DONE for BigDecimal.divide in 13.057509250s
Benchmark 1 DONE for BigDecimal.divide in 14.191002375s
Benchmark 2 DONE for BigDecimal.divide in 13.054583125s
Benchmark 3 DONE for BigDecimal.divide in 13.033955416s
Benchmark 4 DONE for BigDecimal.divide in 12.736495125s
Preparing for BigDecimal.hashCode (warmup)
Benchmarking for BigDecimal.hashCode
Benchmark 0 DONE for BigDecimal.hashCode in 1.901092083s
Benchmark 1 DONE for BigDecimal.hashCode in 1.885407167s
Benchmark 2 DONE for BigDecimal.hashCode in 1.858878375s
Benchmark 3 DONE for BigDecimal.hashCode in 1.875259292s
Benchmark 4 DONE for BigDecimal.hashCode in 1.908517084s
Preparing for BigDecimal.toStringExpanded (warmup)
Benchmarking for BigDecimal.toStringExpanded
Benchmark 0 DONE for BigDecimal.toStringExpanded in 3.042343208s
Benchmark 1 DONE for BigDecimal.toStringExpanded in 3.001425166s
Benchmark 2 DONE for BigDecimal.toStringExpanded in 3.002280917s
Benchmark 3 DONE for BigDecimal.toStringExpanded in 3.522021500s
Benchmark 4 DONE for BigDecimal.toStringExpanded in 3.054474583s
Preparing for BigDecimal.toPlainString (warmup)
Benchmarking for BigDecimal.toPlainString
Benchmark 0 DONE for BigDecimal.toPlainString in 3.159102333s
Benchmark 1 DONE for BigDecimal.toPlainString in 3.173485625s
Benchmark 2 DONE for BigDecimal.toPlainString in 3.154405375s
Benchmark 3 DONE for BigDecimal.toPlainString in 3.207668833s
Benchmark 4 DONE for BigDecimal.toPlainString in 3.160036542s
Preparing for BigDecimal.roundToDigitPosition (warmup)
Benchmarking for BigDecimal.roundToDigitPosition
Benchmark 0 DONE for BigDecimal.roundToDigitPosition in 3.072366625s
Benchmark 1 DONE for BigDecimal.roundToDigitPosition in 3.188162084s
Benchmark 2 DONE for BigDecimal.roundToDigitPosition in 3.270040459s
Benchmark 3 DONE for BigDecimal.roundToDigitPosition in 3.111248666s
Benchmark 4 DONE for BigDecimal.roundToDigitPosition in 3.113283666s
Preparing for BigDecimal.pow (warmup)
Benchmarking for BigDecimal.pow
Benchmark 0 DONE for BigDecimal.pow in 8.328544792s
Benchmark 1 DONE for BigDecimal.pow in 8.325586167s
Benchmark 2 DONE for BigDecimal.pow in 8.275277917s
Benchmark 3 DONE for BigDecimal.pow in 8.349723333s
Benchmark 4 DONE for BigDecimal.pow in 8.302954417s
Preparing for BigDecimal.isZero (warmup)
Benchmarking for BigDecimal.isZero
Benchmark 0 DONE for BigDecimal.isZero in 42.412083ms
Benchmark 1 DONE for BigDecimal.isZero in 41.328750ms
Benchmark 2 DONE for BigDecimal.isZero in 150.646833ms
Benchmark 3 DONE for BigDecimal.isZero in 133.404166ms
Benchmark 4 DONE for BigDecimal.isZero in 232.220083ms
Preparing for BigInteger.pow (warmup)
Benchmarking for BigInteger.pow
Benchmark 0 DONE for BigInteger.pow in 514.404625ms
Benchmark 1 DONE for BigInteger.pow in 536.982250ms
Benchmark 2 DONE for BigInteger.pow in 514.942041ms
Benchmark 3 DONE for BigInteger.pow in 514.049500ms
Benchmark 4 DONE for BigInteger.pow in 517.884125ms
Preparing for BigInteger.TEN.pow (warmup)
Benchmarking for BigInteger.TEN.pow
Benchmark 0 DONE for BigInteger.TEN.pow in 120.219459ms
Benchmark 1 DONE for BigInteger.TEN.pow in 118.888375ms
Benchmark 2 DONE for BigInteger.TEN.pow in 119.592708ms
Benchmark 3 DONE for BigInteger.TEN.pow in 122.172834ms
Benchmark 4 DONE for BigInteger.TEN.pow in 120.933083ms
Preparing for BigInteger.isZero (warmup)
Benchmarking for BigInteger.isZero
Benchmark 0 DONE for BigInteger.isZero in 32.849709ms
Benchmark 1 DONE for BigInteger.isZero in 33.691167ms
Benchmark 2 DONE for BigInteger.isZero in 33.939750ms
Benchmark 3 DONE for BigInteger.isZero in 32.806375ms
Benchmark 4 DONE for BigInteger.isZero in 32.639459ms
Benchmark report:

| Method |  run 1 | run 2 | run 3 | run 4 | run 5  | Average |
|--------|-------|------|------|------|------ |---------|
| BigDecimal.add |  3.756398666s | 3.476847917s | 3.471759167s | 3.680526333s | 3.744516542s  | 3.626009725s |
| BigDecimal.divide |  13.057509250s | 14.191002375s | 13.054583125s | 13.033955416s | 12.736495125s  | 13.214709058s |
| BigDecimal.hashCode |  1.901092083s | 1.885407167s | 1.858878375s | 1.875259292s | 1.908517084s  | 1.885830800s |
| BigDecimal.isZero |  42.412083ms | 41.328750ms | 150.646833ms | 133.404166ms | 232.220083ms  | 120.002383ms |
| BigDecimal.multiply |  4.121463166s | 3.832564208s | 3.858924375s | 3.864766458s | 3.799875833s  | 3.895518808s |
| BigDecimal.parseStringWithMode |  2.847489542s | 2.801993041s | 2.737596042s | 2.727944292s | 2.862519750s  | 2.795508533s |
| BigDecimal.pow |  8.328544792s | 8.325586167s | 8.275277917s | 8.349723333s | 8.302954417s  | 8.316417325s |
| BigDecimal.roundToDigitPosition |  3.072366625s | 3.188162084s | 3.270040459s | 3.111248666s | 3.113283666s  | 3.151020300s |
| BigDecimal.subtract |  3.532442291s | 3.275783083s | 3.332147292s | 3.390437417s | 3.284431833s  | 3.363048383s |
| BigDecimal.toPlainString |  3.159102333s | 3.173485625s | 3.154405375s | 3.207668833s | 3.160036542s  | 3.170939741s |
| BigDecimal.toStringExpanded |  3.042343208s | 3.001425166s | 3.002280917s | 3.522021500s | 3.054474583s  | 3.124509074s |
| BigInteger.TEN.pow |  120.219459ms | 118.888375ms | 119.592708ms | 122.172834ms | 120.933083ms  | 120.361291ms |
| BigInteger.isZero |  32.849709ms | 33.691167ms | 33.939750ms | 32.806375ms | 32.639459ms  | 33.185292ms |
| BigInteger.pow |  514.404625ms | 536.982250ms | 514.942041ms | 514.049500ms | 517.884125ms  | 519.652508ms |

</details>



